### PR TITLE
fix #30  scrollbar and scrollRowByRow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 ## 0.11.2
 * Bugfix:
   - fix: areaSelection keyboard left right not work correctly when table has fixed sticky column
-
+  - fix(#30): horizontal scrollbar has wrong position when `props.scrollbar` && `props.scrollRowByRow` be set. 
+  
 ## 0.11.1
 * Bugfix
   - fix: areaSelection keyboard not work correctly when `props.footerData` is set.

--- a/src/StkTable/StkTable.vue
+++ b/src/StkTable/StkTable.vue
@@ -26,7 +26,7 @@
             'scroll-row-by-row': isSRBRActive,
             'scrollbar-on': scrollbarOptions.enabled,
             'is-area-selecting': isAreaSelecting,
-            'exp-scroll-y': experimental?.scrollY,
+            'exp-scroll-y': isExperimentalScrollY,
         }"
         :tabindex="props.areaSelection ? 0 : void 0"
         :style="{
@@ -41,7 +41,7 @@
         @scroll="onTableScroll"
         @wheel="onTableWheel"
     >
-        <div v-if="!experimental?.scrollY && SRBRTotalHeight" class="row-by-row-table-height" :style="`height: ${SRBRTotalHeight}px`"></div>
+        <div v-if="!isExperimentalScrollY && SRBRTotalHeight" class="row-by-row-table-height" :style="`height: ${SRBRTotalHeight}px`"></div>
 
         <div v-if="colResizable" ref="colResizeIndicatorRef" class="column-resize-indicator"></div>
 
@@ -132,7 +132,7 @@
                     @mouseover="onCellMouseOver"
                 >
                     <tr
-                        v-if="!experimental?.scrollY && virtual_on && !isSRBRActive"
+                        v-if="!isExperimentalScrollY && virtual_on && !isSRBRActive"
                         :style="`height:${virtualScroll.offsetTop}px`"
                         class="padding-top-tr"
                     >
@@ -208,7 +208,7 @@
                         </template>
                         <td v-if="virtualX_on" class="vt-x-right"></td>
                     </tr>
-                    <template v-if="!experimental?.scrollY">
+                    <template v-if="!isExperimentalScrollY">
                         <tr v-if="virtual_on && !isSRBRActive" :style="`height: ${virtual_offsetBottom}px`"></tr>
                         <tr v-if="SRBRBottomHeight" :style="`height: ${SRBRBottomHeight}px`"></tr>
                     </template>
@@ -798,6 +798,13 @@ const scrollbarOptions = computed(() => ({
     ...(typeof props.scrollbar === 'boolean' ? { enabled: props.scrollbar } : props.scrollbar),
 }));
 
+const isExperimentalScrollY = computed(() => {
+    if (scrollbarOptions.value?.enabled && props.scrollRowByRow) {
+        return true;
+    }
+    return props.experimental?.scrollY;
+});
+
 const rowKeyGenCache = new WeakMap();
 
 const [isSRBRActive] = useScrollRowByRow(props, tableContainerRef);
@@ -825,7 +832,18 @@ const [
     updateVirtualScrollX,
     setAutoHeight,
     clearAllAutoHeight,
-] = useVirtualScroll(props, tableContainerRef, trRef, dataSourceCopy, tableHeaderLast, tableHeaders, rowKeyGen, maxRowSpan, scrollbarOptions);
+] = useVirtualScroll(
+    props,
+    tableContainerRef,
+    trRef,
+    dataSourceCopy,
+    tableHeaderLast,
+    tableHeaders,
+    rowKeyGen,
+    maxRowSpan,
+    scrollbarOptions,
+    isExperimentalScrollY,
+);
 
 /** requestAnimationFrame throttled version of updateVirtualScrollY for smoother wheel scrolling */
 const rafUpdateVirtualScrollYForWheel = rafThrottle((scrollTop: number) => {
@@ -839,6 +857,7 @@ const [scrollbar, showScrollbar, onVerticalScrollbarMouseDown, onHorizontalScrol
     virtualScrollX,
     updateVirtualScrollY,
     scrollbarOptions,
+    isExperimentalScrollY,
 );
 
 const [hiddenCellMap, mergeCellsWrapper, hoverMergedCells, updateHoverMergedCells, activeMergedCells, updateActiveMergedCells] = useMergeCells(
@@ -1438,7 +1457,7 @@ function onTableWheel(e: WheelEvent) {
         if (isWheeling()) {
             e.preventDefault();
         }
-        if (props.experimental?.scrollY) {
+        if (isExperimentalScrollY.value) {
             rafUpdateVirtualScrollYForWheel(scrollTop + deltaY);
             updateCustomScrollbar();
         } else {

--- a/src/StkTable/useScrollbar.ts
+++ b/src/StkTable/useScrollbar.ts
@@ -27,6 +27,7 @@ export function useScrollbar(
     virtualScrollX: Ref<VirtualScrollXStore>,
     updateVirtualScrollY: (sTop?: number) => void,
     scrollbarOptions: Ref<Required<ScrollbarOptions>>,
+    isExperimentalScrollY: Ref<boolean | undefined>,
 ) {
     const showScrollbar = ref({ x: false, y: false });
     const scrollbar = ref({ h: 0, w: 0, t: 0, l: 0 });
@@ -114,7 +115,7 @@ export function useScrollbar(
         const trackRange = containerHeight - scrollbar.value.h;
         const scrollDelta = (deltaY / trackRange) * scrollRange;
 
-        if (props.experimental?.scrollY) {
+        if (isExperimentalScrollY.value) {
             const ratio = containerHeight / scrollHeight;
             const top = Math.round((dragStartTop + scrollDelta) * ratio);
             const maxTop = containerHeight - scrollbar.value.h;

--- a/src/StkTable/useVirtualScroll.ts
+++ b/src/StkTable/useVirtualScroll.ts
@@ -57,6 +57,7 @@ export function useVirtualScroll<DT extends Record<string, any>>(
     rowKeyGen: RowKeyGen,
     maxRowSpan: Map<UniqKey, number>,
     scrollbarOptions: Ref<Required<ScrollbarOptions>>,
+    isExperimentalScrollY: Ref<boolean | undefined>,
 ) {
     const tableHeaderHeight = computed(() => props.headerRowHeight * tableHeaders.value.length);
 
@@ -276,7 +277,7 @@ export function useVirtualScroll<DT extends Record<string, any>>(
         const { enabled: scrollbarEnable } = scrollbarOptions.value;
         if (scrollbarEnable) {
             vsValue.scrollHeight = scrollHeight;
-            if (props.experimental?.scrollY) {
+            if (isExperimentalScrollY.value) {
                 let maxTop: number;
                 sTop = sTop < 0 ? 0 : sTop < (maxTop = scrollHeight - containerHeight) ? sTop : maxTop;
                 vsValue.translateY = props.scrollRowByRow ? 0 : -(sTop % rowHeight);


### PR DESCRIPTION
* Bugfix:
  - fix: areaSelection keyboard left right not work correctly when table has fixed sticky column
  - fix(#30): horizontal scrollbar has wrong position when `props.scrollbar` && `props.scrollRowByRow` be set. 
  