### PR TITLE
feat(area-selection): add setAreaSelection api and index resolver utils

### DIFF
--- a/src/StkTable/StkTable.vue
+++ b/src/StkTable/StkTable.vue
@@ -149,7 +149,7 @@
                         ref="trRef"
                         :key="rowKeyGen(row)"
                         v-bind="getTRProps(row, rowIndex)"
-                        @drop="onTrDrop($event, getRowIndex(rowIndex))"
+                        @drop="onTrDrop($event, getAbsoluteRowIndex(rowIndex))"
                         @mouseleave="onTrMouseLeave"
                     >
                         <td v-if="virtualX_on" class="vt-x-left"></td>
@@ -176,7 +176,7 @@
                                         tabindex="-1"
                                         :col="col"
                                         :row="row"
-                                        :rowIndex="getRowIndex(rowIndex)"
+                                        :rowIndex="getAbsoluteRowIndex(rowIndex)"
                                         :colIndex="colIndex"
                                         :cellValue="row && row[col.dataIndex]"
                                         :expanded="row && row.__EXP__"
@@ -186,14 +186,14 @@
                                             <TriangleIcon @click="triangleClick($event, row, col)"></TriangleIcon>
                                         </template>
                                         <template #stkDragIcon>
-                                            <DragHandle @dragstart="onTrDragStart($event, getRowIndex(rowIndex))" />
+                                            <DragHandle @dragstart="onTrDragStart($event, getAbsoluteRowIndex(rowIndex))" />
                                         </template>
                                     </component>
                                     <div v-else-if="!col.type" class="table-cell-wrapper" tabindex="-1" :title="row[col.dataIndex] || ''">
                                         {{ (row && row[col.dataIndex]) !== void 0 ? row && row[col.dataIndex] : getEmptyCellText(col, row) }}
                                     </div>
                                     <div v-else-if="col.type === 'seq'" class="table-cell-wrapper" tabindex="-1">
-                                        {{ (props.seqConfig.startIndex || 0) + getRowIndex(rowIndex) + 1 }}
+                                        {{ (props.seqConfig.startIndex || 0) + getAbsoluteRowIndex(rowIndex) + 1 }}
                                     </div>
                                     <TreeNodeCell
                                         v-else-if="col.type === 'tree-node'"
@@ -204,7 +204,7 @@
                                         @click="triangleClick($event, row, col)"
                                     ></TreeNodeCell>
                                     <div v-else class="table-cell-wrapper" tabindex="-1" :title="row[col.dataIndex] || ''">
-                                        <DragHandle v-if="col.type === 'dragRow'" @dragstart="onTrDragStart($event, getRowIndex(rowIndex))" />
+                                        <DragHandle v-if="col.type === 'dragRow'" @dragstart="onTrDragStart($event, getAbsoluteRowIndex(rowIndex))" />
                                         <TriangleIcon v-else-if="col.type === 'expand'" @click="triangleClick($event, row, col)" />
                                         <span v-if="row[col.dataIndex] != null">{{ row[col.dataIndex] }}</span>
                                     </div>
@@ -308,6 +308,7 @@ import { useTableColumns } from './useTableColumns';
 import { useThDrag } from './useThDrag';
 import { useTrDrag } from './useTrDrag';
 import { useTree } from './useTree';
+import { useIndexResolver } from './useIndexResolver';
 import { useVirtualScroll } from './useVirtualScroll';
 import { useWheeling } from './useWheeling';
 import { useFocusoutControll } from './utils/useFocusoutControll';
@@ -900,6 +901,8 @@ if (props.autoResize) {
     useAutoResize(tableContainerRef, initVirtualScroll, props, 200);
 }
 
+const [getRowIndex, getColumnIndex] = useIndexResolver(dataSourceCopy, tableHeaderLast, rowKeyGen);
+
 const {
     config: areaSelectionConfig,
     isSelecting: isAreaSelecting,
@@ -907,6 +910,7 @@ const {
     getClass: getAreaSelectionClasses,
     getRowClass: getAreaSelectionRowClass,
     get: getSelectedArea,
+    set: setAreaSelection,
     clear: clearSelectedArea,
     copy: copySelectedArea,
 } = ON_DEMAND_FEATURE[useAreaSelectionName](
@@ -920,6 +924,8 @@ const {
     scrollTo,
     virtualScroll,
     virtualScrollX,
+    getRowIndex,
+    getColumnIndex,
 );
 
 /** 键盘箭头滚动 */
@@ -1148,7 +1154,7 @@ const cellStyleMap = computed(() => {
     };
 });
 
-function getRowIndex(rowIndex: number) {
+function getAbsoluteRowIndex(rowIndex: number) {
     return rowIndex + virtualScroll.value.startIndex;
 }
 
@@ -1167,7 +1173,7 @@ function getHeaderTitle(col: StkTableColumn<DT>): string {
 }
 
 function getTRProps(row: PrivateRowDT | null | undefined, index: number) {
-    const rowIndex = getRowIndex(index);
+    const rowIndex = getAbsoluteRowIndex(index);
     const rowKey = rowKeyGen(row);
 
     const classList = [props.rowClassName(row, rowIndex), row?.__EXP__ ? 'expanded' : '', row?.__EXP_R__ ? 'expanded-row' : ''];
@@ -1268,7 +1274,7 @@ function getTDProps(row: PrivateRowDT | null | undefined, col: StkTableColumn<Pr
 
     // area selection style
     if (areaSelectionConfig.value.enabled) {
-        const absRowIndex = getRowIndex(rowIndex);
+        const absRowIndex = getAbsoluteRowIndex(rowIndex);
         classList.push(...getAreaSelectionClasses(cellKey, absRowIndex, colKey));
     }
 
@@ -1714,6 +1720,8 @@ defineExpose({
      * @see {@link getTableData}
      */
     getTableData,
+    getRowIndex,
+    getColumnIndex,
     /**
      * 设置展开的行
      *
@@ -1749,6 +1757,7 @@ defineExpose({
      * @see {@link getSelectedArea}
      */
     getSelectedArea,
+    setAreaSelection,
     /**
      * 清空拖选选区
      *

--- a/src/StkTable/features/useAreaSelection.ts
+++ b/src/StkTable/features/useAreaSelection.ts
@@ -1,5 +1,14 @@
 import { Ref, ShallowRef, computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
-import { AreaSelectionConfig, AreaSelectionRange, CellKeyGen, ColKeyGen, StkTableColumn, UniqKey } from '../types';
+import {
+    AreaSelectionConfig,
+    AreaSelectionRange,
+    CellKeyGen,
+    ColKeyGen,
+    StkTableColumn,
+    UniqKey,
+    AreaSelectionSetterRange,
+    AreaSelectionSetterOption,
+} from '../types';
 import { VirtualScrollStore, VirtualScrollXStore } from '../useVirtualScroll';
 import { getClosestColKey, getClosestTrIndex } from '../utils';
 import { getCalculatedColWidth } from '../utils/constRefUtils';
@@ -21,6 +30,8 @@ export function useAreaSelection<DT extends Record<string, any>>(
     scrollTo: (top: number | null, left: number | null) => void,
     virtualScroll: Ref<VirtualScrollStore>,
     virtualScrollX: Ref<VirtualScrollXStore>,
+    getRowIndex: (row: DT) => number,
+    getColumnIndex: (col: StkTableColumn<DT>) => number,
 ) {
     /**
      * 自动滚动：鼠标距容器边缘多少px开始触发
@@ -883,12 +894,75 @@ export function useAreaSelection<DT extends Record<string, any>>(
         isSelecting.value = false;
     }
 
+    function setAreaSelection(ranges?: AreaSelectionSetterRange<DT>, option: AreaSelectionSetterOption = {}): AreaSelectionRange[] {
+        if (!config.value.enabled) return selectionRanges.value;
+
+        const { silent = true, scrollToView = false } = option;
+        const rowCount = dataSourceCopy.value.length;
+        const colCount = tableHeaderLast.value.length;
+
+        if (rowCount <= 0 || colCount <= 0) {
+            clearSelectedArea();
+            if (!silent) emitSelectionChange();
+            return selectionRanges.value;
+        }
+
+        const maxRow = rowCount - 1;
+        const maxCol = colCount - 1;
+
+        let beginRow = 0;
+        let endRow = maxRow;
+        let beginCol = 0;
+        let endCol = maxCol;
+
+        if (ranges) {
+            const begin = ranges.begin;
+            const end = ranges.end ?? begin;
+            const beginColInput = begin.col && typeof begin.col === 'object' ? getColumnIndex(begin.col) : begin.col;
+            const endColInput = end.col && typeof end.col === 'object' ? getColumnIndex(end.col) : end.col;
+
+            beginRow = typeof begin.row === 'object' ? getRowIndex(begin.row) : begin.row;
+            endRow = typeof end.row === 'object' ? getRowIndex(end.row) : end.row;
+
+            if (beginColInput === void 0 && endColInput === void 0) {
+                beginCol = 0;
+                endCol = maxCol;
+            } else if (beginColInput !== void 0 && endColInput === void 0) {
+                beginCol = beginColInput;
+                endCol = beginColInput;
+            } else if (beginColInput === void 0 && endColInput !== void 0) {
+                beginCol = 0;
+                endCol = endColInput;
+            } else {
+                beginCol = beginColInput as number;
+                endCol = endColInput as number;
+            }
+        }
+
+        beginRow = clamp(beginRow, 0, maxRow);
+        endRow = clamp(endRow, 0, maxRow);
+        beginCol = clamp(beginCol, 0, maxCol);
+        endCol = clamp(endCol, 0, maxCol);
+
+        selectionRanges.value = [makeRange(beginRow, beginCol, endRow, endCol)];
+        anchorCell = { rowIndex: beginRow, colIndex: beginCol };
+        isSelecting.value = false;
+
+        if (scrollToView) {
+            scrollToCell(endRow, endCol);
+        }
+
+        if (!silent) emitSelectionChange();
+        return selectionRanges.value;
+    }
+
     return {
         config,
         isSelecting,
         getClass: getAreaSelectionClasses,
         getRowClass: getAreaSelectionRowClasses,
         get: getSelectedArea,
+        set: setAreaSelection,
         clear: clearSelectedArea,
         copy: copySelectedArea,
         onMD: onSelectionMouseDown,

--- a/src/StkTable/registerFeature.ts
+++ b/src/StkTable/registerFeature.ts
@@ -18,6 +18,7 @@ export const ON_DEMAND_FEATURE: OnDemandFeature = {
             getClass: () => [],
             getRowClass: () => [],
             get: () => ({ rows: [], cols: [], ranges: [] }),
+            set: () => [],
             clear: () => {},
             copy: () => '',
         };

--- a/src/StkTable/types/index.ts
+++ b/src/StkTable/types/index.ts
@@ -409,6 +409,17 @@ export type AreaSelectionConfig<T extends Record<string, any> = any> = {
     };
 };
 
+/** 获取选中的单元格信息 */
+export type AreaSelectionSetterRange<DT extends Record<string, any>> = {
+    begin: { row: number | DT; col?: number | StkTableColumn<DT> };
+    end?: { row: number | DT; col?: number | StkTableColumn<DT> };
+};
+
+export type AreaSelectionSetterOption = {
+    silent?: boolean;
+    scrollToView?: boolean;
+};
+
 /** 实验性功能配置 */
 export type ExperimentalConfig = {
     /** use transform to simulate scroll */

--- a/src/StkTable/useIndexResolver.ts
+++ b/src/StkTable/useIndexResolver.ts
@@ -1,0 +1,29 @@
+import type { Ref } from 'vue';
+import type { StkTableColumn, UniqKey } from './types';
+
+export function useIndexResolver<DT extends Record<string, any>>(
+    dataSourceRef: Ref<DT[]>,
+    columnsRef: Ref<StkTableColumn<DT>[]>,
+    rowKeyGen: (row: DT | null | undefined) => UniqKey,
+) {
+    function getRowIndex(row: DT): number {
+        const targetKey = rowKeyGen(row);
+        const data = dataSourceRef.value;
+        for (let i = 0; i < data.length; i++) {
+            if (rowKeyGen(data[i]) === targetKey) return i;
+        }
+        return -1;
+    }
+
+    function getColumnIndex(column: StkTableColumn<DT>): number {
+        const targetDataIndex = column?.dataIndex;
+        if (targetDataIndex === void 0 || targetDataIndex === null) return -1;
+        const columns = columnsRef.value;
+        for (let i = 0; i < columns.length; i++) {
+            if (columns[i]?.dataIndex === targetDataIndex) return i;
+        }
+        return -1;
+    }
+
+    return [getRowIndex, getColumnIndex] as const;
+}

--- a/test/StkTable.browser.test.js
+++ b/test/StkTable.browser.test.js
@@ -2,8 +2,10 @@
  * @vitest-environment happy-dom
  */
 import { mount } from '@vue/test-utils';
-import { StkTable } from '@/StkTable';
+import { StkTable, registerFeature, useAreaSelection } from '@/StkTable';
 import { describe, expect, test } from 'vitest';
+
+registerFeature(useAreaSelection);
 
 describe('StkTable.vue', () => {
     const columns = [
@@ -65,5 +67,106 @@ describe('StkTable.vue', () => {
             noDataFull: true,
         });
         expect(wrapper.find('.stk-table-no-data.no-data-full').exists()).toBeTruthy();
+    });
+});
+
+describe('StkTable.vue area selection expose', () => {
+    const columns = [
+        { dataIndex: 'c0', title: 'C0', width: '120px' },
+        { dataIndex: 'c1', title: 'C1', width: '120px' },
+        { dataIndex: 'c2', title: 'C2', width: '120px' },
+        { dataIndex: 'c3', title: 'C3', width: '120px' },
+        { dataIndex: 'c4', title: 'C4', width: '120px' },
+        { dataIndex: 'c5', title: 'C5', width: '120px' },
+    ];
+    const dataSource = new Array(80).fill(0).map((_, i) => ({
+        id: i,
+        c0: `r${i}-c0`,
+        c1: `r${i}-c1`,
+        c2: `r${i}-c2`,
+        c3: `r${i}-c3`,
+        c4: `r${i}-c4`,
+        c5: `r${i}-c5`,
+    }));
+
+    function createWrapper() {
+        return mount(StkTable, {
+            props: {
+                rowKey: 'id',
+                areaSelection: true,
+                virtual: true,
+                width: '220px',
+                columns,
+                dataSource,
+            },
+        });
+    }
+
+    test('setAreaSelection supports default full selection and row-only', () => {
+        const wrapper = createWrapper();
+        const vm = wrapper.vm;
+
+        let ranges = vm.setAreaSelection();
+        expect(ranges).toHaveLength(1);
+        expect(ranges[0].index.begin).toEqual({ row: 0, col: 0 });
+        expect(ranges[0].index.end).toEqual({ row: dataSource.length - 1, col: columns.length - 1 });
+        expect(ranges).toEqual(vm.getSelectedArea().ranges);
+
+        ranges = vm.setAreaSelection({ begin: { row: 1 } });
+        expect(ranges[0].index.begin).toEqual({ row: 1, col: 0 });
+        expect(ranges[0].index.end).toEqual({ row: 1, col: columns.length - 1 });
+
+        wrapper.unmount();
+    });
+
+    test('setAreaSelection supports col fill rules and silent option', () => {
+        const wrapper = createWrapper();
+        const vm = wrapper.vm;
+
+        vm.setAreaSelection({ begin: { row: 1, col: 2 }, end: { row: 3 } });
+        let ranges = vm.getSelectedArea().ranges;
+        expect(ranges[0].index.begin).toEqual({ row: 1, col: 2 });
+        expect(ranges[0].index.end).toEqual({ row: 3, col: 2 });
+
+        vm.setAreaSelection({ begin: { row: 1 }, end: { row: 3, col: 4 } });
+        ranges = vm.getSelectedArea().ranges;
+        expect(ranges[0].index.begin).toEqual({ row: 1, col: 0 });
+        expect(ranges[0].index.end).toEqual({ row: 3, col: 4 });
+
+        const emittedCountBefore = wrapper.emitted('area-selection-change')?.length || 0;
+        vm.setAreaSelection({ begin: { row: 2, col: 1 } });
+        expect((wrapper.emitted('area-selection-change')?.length || 0) - emittedCountBefore).toBe(0);
+
+        vm.setAreaSelection({ begin: { row: 2, col: 1 } }, { silent: false });
+        expect((wrapper.emitted('area-selection-change')?.length || 0) - emittedCountBefore).toBe(1);
+
+        wrapper.unmount();
+    });
+
+    test('setAreaSelection supports scrollToView', () => {
+        const wrapper = createWrapper();
+        const vm = wrapper.vm;
+        const container = wrapper.find('.stk-table').element;
+
+        expect(container.scrollTop).toBe(0);
+        expect(container.scrollLeft).toBe(0);
+
+        vm.setAreaSelection({ begin: { row: 70, col: 5 } }, { scrollToView: true });
+        expect(container.scrollTop > 0 || container.scrollLeft > 0).toBe(true);
+
+        wrapper.unmount();
+    });
+
+    test('index resolver methods: getRowIndex/getColumnIndex', () => {
+        const wrapper = createWrapper();
+        const vm = wrapper.vm;
+
+        expect(vm.getRowIndex(dataSource[3])).toBe(3);
+        expect(vm.getRowIndex({ id: 9999, c0: 'x' })).toBe(-1);
+
+        expect(vm.getColumnIndex(columns[2])).toBe(2);
+        expect(vm.getColumnIndex({ dataIndex: '__not_exists__' })).toBe(-1);
+
+        wrapper.unmount();
     });
 });


### PR DESCRIPTION
1. 新增useIndexResolver工具，用于获取行列索引
2. 为区域选框功能添加setAreaSelection方法，支持自定义选区范围、静默更新和自动滚动
3. 重构表格行索引计算逻辑，统一使用绝对行索引
4. 新增区域选框相关类型定义并注册对应特性到表格
5. 新增浏览器端测试用例覆盖区域选框API功能