### PR TITLE
feat: add NumberCell and ChangeCell built-in custom cells

### DIFF
--- a/docs-demo/advanced/custom-cells/ChangeCell/index.vue
+++ b/docs-demo/advanced/custom-cells/ChangeCell/index.vue
@@ -1,0 +1,47 @@
+<template>
+    <StkTable row-key="code" :columns="columns" :data-source="dataSource" />
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue';
+import StkTable from '../../../StkTable.vue';
+// 开发中功能：此处从源码导入；发布后可改为 import { createChangeCell, createNumberCell } from 'stk-table-vue'
+import { createChangeCell, createNumberCell, type StkTableColumn } from '../../../../src/StkTable';
+import { useI18n } from '../../../hooks/useI18n/index';
+
+const { t } = useI18n();
+
+// 现价：普通数字格式化
+const { NumberCell: PriceCtor } = createNumberCell({ decimals: 2 });
+const priceCell = PriceCtor();
+
+// 涨跌额：带符号 + 箭头，默认 A 股涨红跌绿
+const { ChangeCell: ChangeCtor, formatCopyText: changeCopy } = createChangeCell({ decimals: 2, showSign: true, arrow: true });
+const changeCell = ChangeCtor();
+
+// 涨跌幅：百分比 + 符号 + 箭头
+const { ChangeCell: PctCtor, formatCopyText: pctCopy } = createChangeCell({ percent: true, decimals: 2, showSign: true, arrow: true });
+const pctCell = PctCtor();
+
+interface RowData {
+    code: string;
+    price: number;
+    change: number;
+    changePct: number;
+}
+
+const columns: StkTableColumn<RowData>[] = [
+    { title: t('code'), dataIndex: 'code', width: 100 },
+    { title: t('price'), dataIndex: 'price', width: 100, align: 'right', customCell: priceCell },
+    { title: t('change'), dataIndex: 'change', width: 120, align: 'right', customCell: changeCell, formatCopyText: changeCopy },
+    { title: t('changePercent'), dataIndex: 'changePct', width: 120, align: 'right', customCell: pctCell, formatCopyText: pctCopy },
+];
+
+const dataSource = ref<RowData[]>([
+    { code: '600519', price: 1685.32, change: 23.45, changePct: 0.0141 },
+    { code: '000858', price: 152.18, change: -3.72, changePct: -0.0239 },
+    { code: '300750', price: 198.65, change: 8.9, changePct: 0.0469 },
+    { code: '002594', price: 245.0, change: 0, changePct: 0 },
+    { code: '601318', price: 48.76, change: -1.23, changePct: -0.0246 },
+]);
+</script>

--- a/docs-demo/advanced/custom-cells/NumberCell/index.vue
+++ b/docs-demo/advanced/custom-cells/NumberCell/index.vue
@@ -1,0 +1,47 @@
+<template>
+    <StkTable row-key="code" :columns="columns" :data-source="dataSource" />
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue';
+import StkTable from '../../../StkTable.vue';
+// 开发中功能：此处从源码导入；发布后可改为 import { createNumberCell } from 'stk-table-vue'
+import { createNumberCell, type StkTableColumn } from '../../../../src/StkTable';
+import { useI18n } from '../../../hooks/useI18n/index';
+
+const { t } = useI18n();
+
+// 现价：2 位小数 + 千分位
+const { NumberCell: PriceCtor, formatCopyText: priceCopy } = createNumberCell({ decimals: 2 });
+const priceCell = PriceCtor();
+
+// 成交量：万/亿 单位缩放
+const { NumberCell: VolCtor } = createNumberCell({ abbr: 'cn' });
+const volumeCell = VolCtor();
+
+// 成交额：万/亿 缩放 + 货币前缀
+const { NumberCell: AmountCtor } = createNumberCell({ abbr: 'cn', prefix: '¥' });
+const amountCell = AmountCtor();
+
+interface RowData {
+    code: string;
+    price: number;
+    volume: number;
+    turnover: number;
+}
+
+const columns: StkTableColumn<RowData>[] = [
+    { title: t('code'), dataIndex: 'code', width: 100 },
+    { title: t('price'), dataIndex: 'price', width: 110, align: 'right', customCell: priceCell, formatCopyText: priceCopy },
+    { title: t('volume'), dataIndex: 'volume', width: 120, align: 'right', customCell: volumeCell },
+    { title: t('turnover'), dataIndex: 'turnover', width: 140, align: 'right', customCell: amountCell },
+];
+
+const dataSource = ref<RowData[]>([
+    { code: '600519', price: 1685.32, volume: 3456789, turnover: 5823456789 },
+    { code: '000858', price: 152.18, volume: 12345678, turnover: 1878123456 },
+    { code: '300750', price: 198.65, volume: 23456789, turnover: 4623456789 },
+    { code: '601318', price: 48.76, volume: 45678901, turnover: 2223456789 },
+    { code: '600036', price: 36.42, volume: 34567890, turnover: 1258765432 },
+]);
+</script>

--- a/docs-demo/hooks/useI18n/en.ts
+++ b/docs-demo/hooks/useI18n/en.ts
@@ -213,4 +213,9 @@ export const en = {
     techDept: 'Tech Dept',
     productDept: 'Product Dept',
     opsDept: 'Operations Dept',
+    price: 'Price',
+    volume: 'Volume',
+    turnover: 'Turnover',
+    change: 'Change',
+    changePercent: 'Change %',
 };

--- a/docs-demo/hooks/useI18n/ja.ts
+++ b/docs-demo/hooks/useI18n/ja.ts
@@ -213,4 +213,9 @@ export const ja = {
     techDept: '技術部',
     productDept: '製品部',
     opsDept: '運営部',
+    price: '現在値',
+    volume: '出来高',
+    turnover: '売買代金',
+    change: '騰落額',
+    changePercent: '騰落率',
 };

--- a/docs-demo/hooks/useI18n/ko.ts
+++ b/docs-demo/hooks/useI18n/ko.ts
@@ -222,4 +222,9 @@ export const ko = {
     techDept: '기술부',
     productDept: '제품부',
     opsDept: '운영부',
+    price: '현재가',
+    volume: '거래량',
+    turnover: '거래대금',
+    change: '등락액',
+    changePercent: '등락률',
 };

--- a/docs-demo/hooks/useI18n/zh.ts
+++ b/docs-demo/hooks/useI18n/zh.ts
@@ -222,4 +222,9 @@ export const zh = {
     techDept: '技术部',
     productDept: '产品部',
     opsDept: '运营部',
+    price: '现价',
+    volume: '成交量',
+    turnover: '成交额',
+    change: '涨跌额',
+    changePercent: '涨跌幅',
 };

--- a/docs-src/.vitepress/src/config/en.ts
+++ b/docs-src/.vitepress/src/config/en.ts
@@ -86,6 +86,8 @@ export const enConfig = defineConfig({
                                             { text: 'EditableCell', link: '/table/advanced/custom-cells/editable-cell' },
                                             { text: 'FilterCell', link: '/table/advanced/custom-cells/filter-cell' },
                                             { text: 'CheckboxCell', link: '/table/advanced/custom-cells/checkbox-cell' },
+                                            { text: 'NumberCell', link: '/table/advanced/custom-cells/number-cell' },
+                                            { text: 'ChangeCell', link: '/table/advanced/custom-cells/change-cell' },
                                         ],
                                     },
                                 ]

--- a/docs-src/.vitepress/src/config/ja.ts
+++ b/docs-src/.vitepress/src/config/ja.ts
@@ -86,6 +86,8 @@ export const jaConfig = defineConfig({
                                             { text: 'EditableCell 編集可能セル', link: '/table/advanced/custom-cells/editable-cell' },
                                             { text: 'FilterCell フィルター', link: '/table/advanced/custom-cells/filter-cell' },
                                             { text: 'CheckboxCell チェックボックス', link: '/table/advanced/custom-cells/checkbox-cell' },
+                                            { text: 'NumberCell 数値フォーマット', link: '/table/advanced/custom-cells/number-cell' },
+                                            { text: 'ChangeCell 騰落セル', link: '/table/advanced/custom-cells/change-cell' },
                                         ],
                                     },
                                 ]

--- a/docs-src/.vitepress/src/config/ko.ts
+++ b/docs-src/.vitepress/src/config/ko.ts
@@ -86,6 +86,8 @@ export const koConfig = defineConfig({
                                             { text: 'EditableCell 편집 가능 셀', link: '/table/advanced/custom-cells/editable-cell' },
                                             { text: 'FilterCell 필터', link: '/table/advanced/custom-cells/filter-cell' },
                                             { text: 'CheckboxCell 체크박스', link: '/table/advanced/custom-cells/checkbox-cell' },
+                                            { text: 'NumberCell 숫자 포맷', link: '/table/advanced/custom-cells/number-cell' },
+                                            { text: 'ChangeCell 등락 셀', link: '/table/advanced/custom-cells/change-cell' },
                                         ],
                                     },
                                 ]

--- a/docs-src/.vitepress/src/config/zh.ts
+++ b/docs-src/.vitepress/src/config/zh.ts
@@ -112,6 +112,8 @@ export const zhConfig = defineConfig({
                                             { text: 'EditableCell 可编辑单元格', link: '/table/advanced/custom-cells/editable-cell' },
                                             { text: 'FilterCell 筛选', link: '/table/advanced/custom-cells/filter-cell' },
                                             { text: 'CheckboxCell 多选框', link: '/table/advanced/custom-cells/checkbox-cell' },
+                                            { text: 'NumberCell 数字格式化', link: '/table/advanced/custom-cells/number-cell' },
+                                            { text: 'ChangeCell 涨跌单元格', link: '/table/advanced/custom-cells/change-cell' },
                                         ],
                                     },
                                 ]

--- a/docs-src/en/main/table/advanced/custom-cells/change-cell.md
+++ b/docs-src/en/main/table/advanced/custom-cells/change-cell.md
@@ -1,0 +1,41 @@
+# ChangeCell <Badge type="tip" text="NEW" />
+
+On top of NumberCell's formatting, ChangeCell adds rise/fall coloring and arrows: it colors the value as rise / fall / flat based on its sign, can switch between A-share coloring (rise red, fall green) and international coloring (rise green, fall red), and can show ▲/▼ arrows. The coloring adapts automatically to the table's light/dark theme.
+
+### Basic Usage
+
+Create a ChangeCell component via the `createChangeCell` factory function and use it as `customCell`. It is recommended to set `align: 'right'` on the column for numeric alignment.
+
+<demo vue="advanced/custom-cells/ChangeCell/index.vue" github="https://github.com/ja-plus/stk-table-vue/tree/master/docs-demo/advanced/custom-cells/ChangeCell/index.vue"></demo>
+
+```ts
+const { ChangeCell, formatCopyText } = createChangeCell({ decimals: 2, showSign: true, arrow: true });
+const ChangeCellComp = ChangeCell(); // the factory returns a component constructor; call it once
+
+const columns = [
+    { title: 'Change', dataIndex: 'change', align: 'right', customCell: ChangeCellComp, formatCopyText },
+];
+```
+
+### Configuration Options
+
+The configuration object `CreateChangeCellOptions` inherits all of [NumberCell's formatting options](./number-cell#configuration-options) and additionally provides coloring and arrow settings:
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| colorReverse | `boolean` | `false` | Reverse rise/fall colors: `false`=A-share (rise red, fall green), `true`=international (rise green, fall red) |
+| arrow | `boolean` | `false` | Whether to show the rise/fall arrow (positive ▲ / negative ▼ / flat and empty hidden) |
+| riseColor | `string` | - | Custom rise color (unaffected by `colorReverse` once set) |
+| fallColor | `string` | - | Custom fall color |
+| flatColor | `string` | - | Custom flat color |
+
+The remaining formatting options (`decimals`, `showSign`, `percent`, `prefix`, etc.) are exactly the same as NumberCell. For example, a change-percentage column commonly uses `{ percent: true, showSign: true, arrow: true }`.
+
+### Rise/Fall Coloring
+
+Coloring is based on the **sign of the cell value**: `> 0` is a rise, `< 0` is a fall, `= 0` (and empty values) is flat.
+
+- The default `colorReverse: false` follows the A-share convention: rise red, fall green
+- Setting `colorReverse: true` switches to the international convention: rise green, fall red
+
+Default colors are defined via CSS variables and are automatically brightened under the dark theme (`.stk-table.dark`). For full customization, pass `riseColor` / `fallColor` / `flatColor`, which then take precedence over `colorReverse`.

--- a/docs-src/en/main/table/advanced/custom-cells/number-cell.md
+++ b/docs-src/en/main/table/advanced/custom-cells/number-cell.md
@@ -1,0 +1,60 @@
+# NumberCell <Badge type="tip" text="NEW" />
+
+NumberCell is a built-in display-only cell that formats numeric values into readable text. It supports decimal places, thousands separators, prefix/suffix, sign display, percentages, unit abbreviation (万/亿, K/M/B) and empty-value placeholders. It is commonly used for market quotes, monetary amounts and statistical data.
+
+### Basic Usage
+
+Create a NumberCell component via the `createNumberCell` factory function and use it as `customCell`. It is recommended to set `align: 'right'` on the column for numeric alignment.
+
+<demo vue="advanced/custom-cells/NumberCell/index.vue" github="https://github.com/ja-plus/stk-table-vue/tree/master/docs-demo/advanced/custom-cells/NumberCell/index.vue"></demo>
+
+The factory also returns a matching `formatCopyText`. Attaching it to the column keeps the text obtained from area selection / copy consistent with what is displayed (otherwise the copied value is the raw, unformatted number).
+
+```ts
+const { NumberCell, formatCopyText } = createNumberCell({ decimals: 2 });
+const NumberCellComp = NumberCell(); // the factory returns a component constructor; call it once
+
+const columns = [
+    { title: 'Price', dataIndex: 'price', align: 'right', customCell: NumberCellComp, formatCopyText },
+];
+```
+
+::: tip Different formats per column
+Each `createNumberCell` fixes one format. If columns need different formats (e.g. price with 2 decimals, volume abbreviated by 万), just create multiple instances.
+:::
+
+### Configuration Options
+
+`createNumberCell` accepts a configuration object `CreateNumberCellOptions` (identical to `FormatNumberOptions`):
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| decimals | `number` | - | Number of decimal places (rounded). Omit to leave decimals untouched |
+| thousands | `boolean` | `true` | Whether to use a thousands separator |
+| prefix | `string` | `''` | Prefix, e.g. `¥`, `$` |
+| suffix | `string` | `''` | Suffix, e.g. `元`, `shares` |
+| showSign | `boolean` | `false` | Whether positive numbers force a `+` sign (negatives always show `-`) |
+| percent | `boolean` | `false` | Percentage mode: value ×100 with a trailing `%`. Mutually exclusive with `abbr` |
+| abbr | `'cn' \| 'en'` | - | Unit abbreviation: `cn`=万/亿, `en`=K/M/B. Mutually exclusive with `percent` |
+| abbrDecimals | `number` | `2` | Decimal places kept after abbreviation |
+| placeholder | `string` | `'--'` | Placeholder for empty (`null`/`undefined`/`''`) or non-numeric values |
+
+### Unit Abbreviation
+
+`abbr` scales the value by magnitude and appends a unit:
+
+- `abbr: 'cn'`: ≥ 100M shows as `亿`, ≥ 10K shows as `万` (e.g. `12345` → `1.23万`, `123456789` → `1.23亿`)
+- `abbr: 'en'`: scales by `K` (thousand) / `M` (million) / `B` (billion) (e.g. `1500` → `1.50K`, `2500000` → `2.50M`)
+
+The decimals after abbreviation are controlled by `abbrDecimals` (default 2).
+
+### formatNumber
+
+The formatting logic is provided by the pure function `formatNumber(value, options)`, which is also exported. You can reuse it outside cells (e.g. footer totals, tooltips):
+
+```ts
+import { formatNumber } from 'stk-table-vue';
+
+formatNumber(1234567.891, { decimals: 2 }); // '1,234,567.89'
+formatNumber(0.0523, { percent: true, decimals: 2, showSign: true }); // '+5.23%'
+```

--- a/docs-src/ja/main/table/advanced/custom-cells/change-cell.md
+++ b/docs-src/ja/main/table/advanced/custom-cells/change-cell.md
@@ -1,0 +1,41 @@
+# ChangeCell 騰落セル <Badge type="tip" text="NEW" />
+
+ChangeCell は NumberCell のフォーマット機能に、騰落の色分けと矢印を追加します。セル値の符号に応じて上昇 / 下落 / 変わらずの色を自動で付け、A 株方式（上昇=赤、下落=緑）と国際方式（上昇=緑、下落=赤）を切り替えられ、▲/▼ の矢印も表示できます。色分けはテーブルのライト / ダークテーマに自動で適応します。
+
+### 基本的な使い方
+
+`createChangeCell` ファクトリ関数で ChangeCell コンポーネントを作成し、`customCell` として使用します。数値の位置揃えには、列に `align: 'right'` を設定することをおすすめします。
+
+<demo vue="advanced/custom-cells/ChangeCell/index.vue" github="https://github.com/ja-plus/stk-table-vue/tree/master/docs-demo/advanced/custom-cells/ChangeCell/index.vue"></demo>
+
+```ts
+const { ChangeCell, formatCopyText } = createChangeCell({ decimals: 2, showSign: true, arrow: true });
+const ChangeCellComp = ChangeCell(); // ファクトリはコンポーネントのコンストラクタを返すため、一度呼び出して使用します
+
+const columns = [
+    { title: '騰落額', dataIndex: 'change', align: 'right', customCell: ChangeCellComp, formatCopyText },
+];
+```
+
+### 設定オプション
+
+設定オブジェクト `CreateChangeCellOptions` は [NumberCell のフォーマットオプション](./number-cell#設定オプション) をすべて継承し、さらに色分けと矢印に関する設定を提供します：
+
+| プロパティ | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| colorReverse | `boolean` | `false` | 騰落色の反転：`false`=A 株（上昇赤・下落緑）、`true`=国際（上昇緑・下落赤） |
+| arrow | `boolean` | `false` | 騰落矢印を表示するか（正 ▲ / 負 ▼ / 変わらず・空値は非表示） |
+| riseColor | `string` | - | 上昇色のカスタム指定（設定すると `colorReverse` の影響を受けません） |
+| fallColor | `string` | - | 下落色のカスタム指定 |
+| flatColor | `string` | - | 変わらず色のカスタム指定 |
+
+その他のフォーマットオプション（`decimals`、`showSign`、`percent`、`prefix` など）は NumberCell と完全に同じです。例えば騰落率の列では `{ percent: true, showSign: true, arrow: true }` がよく使われます。
+
+### 騰落の色分け
+
+色分けは**セル値の符号**に基づきます：`> 0` は上昇、`< 0` は下落、`= 0`（および空値）は変わらずです。
+
+- デフォルトの `colorReverse: false` は A 株の慣習：上昇=赤、下落=緑
+- `colorReverse: true` にすると国際的な慣習に切り替わります：上昇=緑、下落=赤
+
+デフォルトの色は CSS 変数で定義され、ダークテーマ（`.stk-table.dark`）では自動的に明るく調整されます。完全にカスタマイズする場合は `riseColor` / `fallColor` / `flatColor` を渡してください。この場合 `colorReverse` より優先されます。

--- a/docs-src/ja/main/table/advanced/custom-cells/number-cell.md
+++ b/docs-src/ja/main/table/advanced/custom-cells/number-cell.md
@@ -1,0 +1,60 @@
+# NumberCell 数値フォーマットセル <Badge type="tip" text="NEW" />
+
+NumberCell は組み込みの表示専用セルで、数値を読みやすいテキストにフォーマットします。小数点以下の桁数、桁区切り、接頭辞・接尾辞、符号表示、パーセント、単位の短縮（万/億、K/M/B）、および空値のプレースホルダーに対応します。市場気配値・金額・統計データの表示によく使われます。
+
+### 基本的な使い方
+
+`createNumberCell` ファクトリ関数で NumberCell コンポーネントを作成し、`customCell` として使用します。数値の位置揃えには、列に `align: 'right'` を設定することをおすすめします。
+
+<demo vue="advanced/custom-cells/NumberCell/index.vue" github="https://github.com/ja-plus/stk-table-vue/tree/master/docs-demo/advanced/custom-cells/NumberCell/index.vue"></demo>
+
+ファクトリは対応する `formatCopyText` も返します。これを列に設定すると、範囲選択 / コピーで得られるテキストが表示内容と一致します（設定しない場合、コピーされるのはフォーマット前の生の値です）。
+
+```ts
+const { NumberCell, formatCopyText } = createNumberCell({ decimals: 2 });
+const NumberCellComp = NumberCell(); // ファクトリはコンポーネントのコンストラクタを返すため、一度呼び出して使用します
+
+const columns = [
+    { title: '現在値', dataIndex: 'price', align: 'right', customCell: NumberCellComp, formatCopyText },
+];
+```
+
+::: tip 列ごとに異なるフォーマット
+`createNumberCell` は 1 つのフォーマットを固定します。列ごとに異なるフォーマット（価格は小数 2 桁、出来高は万単位など）が必要な場合は、複数のインスタンスを作成してください。
+:::
+
+### 設定オプション
+
+`createNumberCell` は設定オブジェクト `CreateNumberCellOptions`（`FormatNumberOptions` と同一）を受け取ります：
+
+| プロパティ | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| decimals | `number` | - | 小数点以下の桁数（四捨五入）。省略時は小数を処理しません |
+| thousands | `boolean` | `true` | 桁区切りを使用するか |
+| prefix | `string` | `''` | 接頭辞（例：`¥`、`$`） |
+| suffix | `string` | `''` | 接尾辞（例：`円`、`株`） |
+| showSign | `boolean` | `false` | 正の数に `+` 記号を強制表示するか（負の数は常に `-`） |
+| percent | `boolean` | `false` | パーセントモード：値 ×100 に `%` を付加。`abbr` と排他 |
+| abbr | `'cn' \| 'en'` | - | 単位の短縮：`cn`=万/億、`en`=K/M/B。`percent` と排他 |
+| abbrDecimals | `number` | `2` | 短縮後に保持する小数桁数 |
+| placeholder | `string` | `'--'` | 空値（`null`/`undefined`/`''`）または非数値のプレースホルダー |
+
+### 単位の短縮
+
+`abbr` は桁数に応じて値を短縮し、単位を付加します：
+
+- `abbr: 'cn'`：1 億以上は `億`、1 万以上は `万` で表示（例：`12345` → `1.23万`、`123456789` → `1.23億`）
+- `abbr: 'en'`：`K`（千）/ `M`（百万）/ `B`（十億）で短縮（例：`1500` → `1.50K`、`2500000` → `2.50M`）
+
+短縮後の小数桁数は `abbrDecimals`（デフォルト 2）で制御します。
+
+### formatNumber
+
+フォーマットロジックは純粋関数 `formatNumber(value, options)` として提供され、エクスポートされています。セル以外（合計行、ツールチップなど）でも直接再利用できます：
+
+```ts
+import { formatNumber } from 'stk-table-vue';
+
+formatNumber(1234567.891, { decimals: 2 }); // '1,234,567.89'
+formatNumber(0.0523, { percent: true, decimals: 2, showSign: true }); // '+5.23%'
+```

--- a/docs-src/ko/main/table/advanced/custom-cells/change-cell.md
+++ b/docs-src/ko/main/table/advanced/custom-cells/change-cell.md
@@ -1,0 +1,41 @@
+# ChangeCell 등락 셀 <Badge type="tip" text="NEW" />
+
+ChangeCell 은 NumberCell 의 포맷 기능 위에 등락 색상과 화살표를 더합니다. 셀 값의 부호에 따라 상승 / 하락 / 보합 색상을 자동으로 적용하고, A주 방식(상승=빨강, 하락=초록)과 국제 방식(상승=초록, 하락=빨강)을 전환할 수 있으며 ▲/▼ 화살표도 표시할 수 있습니다. 색상은 테이블의 라이트 / 다크 테마에 자동으로 적응합니다.
+
+### 기본 사용법
+
+`createChangeCell` 팩토리 함수로 ChangeCell 컴포넌트를 생성하여 `customCell` 로 사용합니다. 숫자 정렬은 열에 `align: 'right'` 를 설정하는 것을 권장합니다.
+
+<demo vue="advanced/custom-cells/ChangeCell/index.vue" github="https://github.com/ja-plus/stk-table-vue/tree/master/docs-demo/advanced/custom-cells/ChangeCell/index.vue"></demo>
+
+```ts
+const { ChangeCell, formatCopyText } = createChangeCell({ decimals: 2, showSign: true, arrow: true });
+const ChangeCellComp = ChangeCell(); // 팩토리는 컴포넌트 생성자를 반환하므로 한 번 호출하여 사용합니다
+
+const columns = [
+    { title: '등락액', dataIndex: 'change', align: 'right', customCell: ChangeCellComp, formatCopyText },
+];
+```
+
+### 설정 옵션
+
+설정 객체 `CreateChangeCellOptions` 는 [NumberCell 의 포맷 옵션](./number-cell#설정-옵션)을 모두 상속하며, 추가로 색상과 화살표 관련 설정을 제공합니다:
+
+| 속성 | 타입 | 기본값 | 설명 |
+|---|---|---|---|
+| colorReverse | `boolean` | `false` | 등락 색상 반전: `false`=A주(상승 빨강, 하락 초록), `true`=국제(상승 초록, 하락 빨강) |
+| arrow | `boolean` | `false` | 등락 화살표 표시 여부(양수 ▲ / 음수 ▼ / 보합·빈 값은 숨김) |
+| riseColor | `string` | - | 상승 색상 사용자 지정(지정 시 `colorReverse` 의 영향을 받지 않음) |
+| fallColor | `string` | - | 하락 색상 사용자 지정 |
+| flatColor | `string` | - | 보합 색상 사용자 지정 |
+
+나머지 포맷 옵션(`decimals`, `showSign`, `percent`, `prefix` 등)은 NumberCell 과 완전히 동일합니다. 예를 들어 등락률 열에는 `{ percent: true, showSign: true, arrow: true }` 를 자주 사용합니다.
+
+### 등락 색상
+
+색상은 **셀 값의 부호**에 따릅니다: `> 0` 은 상승, `< 0` 은 하락, `= 0`(및 빈 값)은 보합입니다.
+
+- 기본값 `colorReverse: false` 는 A주 관습: 상승=빨강, 하락=초록
+- `colorReverse: true` 로 설정하면 국제 관습으로 전환: 상승=초록, 하락=빨강
+
+기본 색상은 CSS 변수로 정의되며 다크 테마(`.stk-table.dark`)에서 자동으로 밝게 조정됩니다. 완전히 사용자 지정하려면 `riseColor` / `fallColor` / `flatColor` 를 전달하세요. 이 경우 `colorReverse` 보다 우선합니다.

--- a/docs-src/ko/main/table/advanced/custom-cells/number-cell.md
+++ b/docs-src/ko/main/table/advanced/custom-cells/number-cell.md
@@ -1,0 +1,60 @@
+# NumberCell 숫자 포맷 셀 <Badge type="tip" text="NEW" />
+
+NumberCell 은 숫자 값을 읽기 쉬운 텍스트로 포맷하는 내장 표시 전용 셀입니다. 소수점 자릿수, 천 단위 구분 기호, 접두사·접미사, 부호 표시, 백분율, 단위 축약(만/억, K/M/B), 빈 값 플레이스홀더를 지원합니다. 시세, 금액, 통계 데이터 표시에 자주 사용됩니다.
+
+### 기본 사용법
+
+`createNumberCell` 팩토리 함수로 NumberCell 컴포넌트를 생성하여 `customCell` 로 사용합니다. 숫자 정렬은 열에 `align: 'right'` 를 설정하는 것을 권장합니다.
+
+<demo vue="advanced/custom-cells/NumberCell/index.vue" github="https://github.com/ja-plus/stk-table-vue/tree/master/docs-demo/advanced/custom-cells/NumberCell/index.vue"></demo>
+
+팩토리는 대응하는 `formatCopyText` 도 반환합니다. 이를 열에 연결하면 영역 선택 / 복사로 얻는 텍스트가 표시 내용과 일치합니다(연결하지 않으면 복사되는 값은 포맷되지 않은 원본 값입니다).
+
+```ts
+const { NumberCell, formatCopyText } = createNumberCell({ decimals: 2 });
+const NumberCellComp = NumberCell(); // 팩토리는 컴포넌트 생성자를 반환하므로 한 번 호출하여 사용합니다
+
+const columns = [
+    { title: '현재가', dataIndex: 'price', align: 'right', customCell: NumberCellComp, formatCopyText },
+];
+```
+
+::: tip 열마다 다른 포맷
+`createNumberCell` 은 하나의 포맷을 고정합니다. 열마다 다른 포맷(예: 가격은 소수 2자리, 거래량은 만 단위 축약)이 필요하면 여러 인스턴스를 만들면 됩니다.
+:::
+
+### 설정 옵션
+
+`createNumberCell` 은 설정 객체 `CreateNumberCellOptions`(`FormatNumberOptions` 와 동일)를 받습니다:
+
+| 속성 | 타입 | 기본값 | 설명 |
+|---|---|---|---|
+| decimals | `number` | - | 소수점 자릿수(반올림). 생략하면 소수를 처리하지 않음 |
+| thousands | `boolean` | `true` | 천 단위 구분 기호 사용 여부 |
+| prefix | `string` | `''` | 접두사(예: `¥`, `$`) |
+| suffix | `string` | `''` | 접미사(예: `원`, `주`) |
+| showSign | `boolean` | `false` | 양수에 `+` 부호 강제 표시 여부(음수는 항상 `-`) |
+| percent | `boolean` | `false` | 백분율 모드: 값 ×100 후 `%` 추가. `abbr` 와 배타적 |
+| abbr | `'cn' \| 'en'` | - | 단위 축약: `cn`=만/억, `en`=K/M/B. `percent` 와 배타적 |
+| abbrDecimals | `number` | `2` | 축약 후 유지할 소수 자릿수 |
+| placeholder | `string` | `'--'` | 빈 값(`null`/`undefined`/`''`) 또는 비숫자일 때의 플레이스홀더 |
+
+### 단위 축약
+
+`abbr` 는 자릿수에 따라 값을 축약하고 단위를 추가합니다:
+
+- `abbr: 'cn'`: 1억 이상은 `억`, 1만 이상은 `만` 으로 표시(예: `12345` → `1.23만`, `123456789` → `1.23억`)
+- `abbr: 'en'`: `K`(천) / `M`(백만) / `B`(십억)로 축약(예: `1500` → `1.50K`, `2500000` → `2.50M`)
+
+축약 후 소수 자릿수는 `abbrDecimals`(기본 2)로 제어합니다.
+
+### formatNumber
+
+포맷 로직은 순수 함수 `formatNumber(value, options)` 로 제공되며 함께 내보내집니다. 셀 외부(합계 행, 툴팁 등)에서도 직접 재사용할 수 있습니다:
+
+```ts
+import { formatNumber } from 'stk-table-vue';
+
+formatNumber(1234567.891, { decimals: 2 }); // '1,234,567.89'
+formatNumber(0.0523, { percent: true, decimals: 2, showSign: true }); // '+5.23%'
+```

--- a/docs-src/main/table/advanced/custom-cells/change-cell.md
+++ b/docs-src/main/table/advanced/custom-cells/change-cell.md
@@ -1,0 +1,41 @@
+# ChangeCell 涨跌单元格 <Badge type="tip" text="NEW" />
+
+ChangeCell 在 NumberCell 的格式化能力之上，叠加涨跌染色与箭头：按单元格值的正负自动染成上涨 / 下跌 / 平盘色，可在 A 股（涨红跌绿）与国际（涨绿跌红）两种配色间切换，并可显示 ▲/▼ 箭头。染色会自动适配表格的明暗主题。
+
+### 基础使用
+
+通过 `createChangeCell` 工厂函数创建 ChangeCell 组件，并将其作为 `customCell` 使用。数字对齐建议在列上设置 `align: 'right'`。
+
+<demo vue="advanced/custom-cells/ChangeCell/index.vue" github="https://github.com/ja-plus/stk-table-vue/tree/master/docs-demo/advanced/custom-cells/ChangeCell/index.vue"></demo>
+
+```ts
+const { ChangeCell, formatCopyText } = createChangeCell({ decimals: 2, showSign: true, arrow: true });
+const ChangeCellComp = ChangeCell(); // 工厂返回组件构造函数，使用时调用一次
+
+const columns = [
+    { title: '涨跌额', dataIndex: 'change', align: 'right', customCell: ChangeCellComp, formatCopyText },
+];
+```
+
+### 配置选项
+
+`createChangeCell` 的配置对象 `CreateChangeCellOptions` 继承全部 [NumberCell 的格式化选项](./number-cell#配置选项)，并额外提供染色与箭头相关配置：
+
+| 属性 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| colorReverse | `boolean` | `false` | 涨跌颜色反转：`false`=A股（涨红跌绿），`true`=国际（涨绿跌红） |
+| arrow | `boolean` | `false` | 是否显示涨跌箭头（正数 ▲ / 负数 ▼ / 平盘与空值不显示） |
+| riseColor | `string` | - | 自定义上涨颜色（传入后不受 `colorReverse` 影响） |
+| fallColor | `string` | - | 自定义下跌颜色 |
+| flatColor | `string` | - | 自定义平盘颜色 |
+
+其余格式化选项（`decimals`、`showSign`、`percent`、`prefix` 等）与 NumberCell 完全一致。例如涨跌幅列常用 `{ percent: true, showSign: true, arrow: true }`。
+
+### 涨跌配色
+
+染色依据**单元格值的正负**：`> 0` 为上涨、`< 0` 为下跌、`= 0`（及空值）为平盘。
+
+- 默认 `colorReverse: false` 为 A 股习惯：涨红、跌绿
+- 设 `colorReverse: true` 切换为国际习惯：涨绿、跌红
+
+默认配色通过 CSS 变量定义，并在暗色主题（`.stk-table.dark`）下自动提亮。如需完全自定义，可传入 `riseColor` / `fallColor` / `flatColor`，此时不再受 `colorReverse` 影响。

--- a/docs-src/main/table/advanced/custom-cells/number-cell.md
+++ b/docs-src/main/table/advanced/custom-cells/number-cell.md
@@ -1,0 +1,60 @@
+# NumberCell 数字格式化单元格 <Badge type="tip" text="NEW" />
+
+NumberCell 是一个内置的纯展示单元格，将数值格式化为易读文本，支持小数位、千分位、前后缀、正负号、百分比、单位缩放（万/亿、K/M/B）以及空值占位。常用于金融行情、金额与统计数据展示。
+
+### 基础使用
+
+通过 `createNumberCell` 工厂函数创建 NumberCell 组件，并将其作为 `customCell` 使用。数字对齐建议在列上设置 `align: 'right'`。
+
+<demo vue="advanced/custom-cells/NumberCell/index.vue" github="https://github.com/ja-plus/stk-table-vue/tree/master/docs-demo/advanced/custom-cells/NumberCell/index.vue"></demo>
+
+工厂同时返回配套的 `formatCopyText`，将其挂到列上可保证区域选取 / 复制得到的文本与展示内容一致（否则复制到的是未格式化的原始值）。
+
+```ts
+const { NumberCell, formatCopyText } = createNumberCell({ decimals: 2 });
+const NumberCellComp = NumberCell(); // 工厂返回组件构造函数，使用时调用一次
+
+const columns = [
+    { title: '现价', dataIndex: 'price', align: 'right', customCell: NumberCellComp, formatCopyText },
+];
+```
+
+::: tip 不同列不同格式
+每次 `createNumberCell` 固定一种格式。若各列格式不同（如价格 2 位小数、成交量按万缩放），分别创建多个实例即可。
+:::
+
+### 配置选项
+
+`createNumberCell` 接受一个配置对象 `CreateNumberCellOptions`（等同于 `FormatNumberOptions`）：
+
+| 属性 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| decimals | `number` | - | 小数位数（四舍五入）。不传则不强制处理小数位 |
+| thousands | `boolean` | `true` | 是否使用千分位分隔符 |
+| prefix | `string` | `''` | 前缀，如 `¥`、`$` |
+| suffix | `string` | `''` | 后缀，如 `元`、`股` |
+| showSign | `boolean` | `false` | 正数是否强制显示 `+` 号（负数始终带 `-`） |
+| percent | `boolean` | `false` | 百分比模式：值 ×100 并追加 `%`。与 `abbr` 互斥 |
+| abbr | `'cn' \| 'en'` | - | 单位缩放：`cn`=万/亿，`en`=K/M/B。与 `percent` 互斥 |
+| abbrDecimals | `number` | `2` | 缩放后保留的小数位 |
+| placeholder | `string` | `'--'` | 空值（`null`/`undefined`/`''`）或非数字时的占位符 |
+
+### 单位缩放
+
+`abbr` 会按数量级自动缩放并追加单位：
+
+- `abbr: 'cn'`：≥ 1 亿显示为 `亿`，≥ 1 万显示为 `万`（如 `12345` → `1.23万`、`123456789` → `1.23亿`）
+- `abbr: 'en'`：按 `K`（千）/ `M`（百万）/ `B`（十亿）缩放（如 `1500` → `1.50K`、`2500000` → `2.50M`）
+
+缩放后的小数位由 `abbrDecimals` 控制（默认 2 位）。
+
+### formatNumber
+
+格式化逻辑由纯函数 `formatNumber(value, options)` 提供，已一并导出。你可以在单元格之外（如表尾合计、tooltip）直接复用：
+
+```ts
+import { formatNumber } from 'stk-table-vue';
+
+formatNumber(1234567.891, { decimals: 2 }); // '1,234,567.89'
+formatNumber(0.0523, { percent: true, decimals: 2, showSign: true }); // '+5.23%'
+```

--- a/src/StkTable/custom-cells/ChangeCell/ChangeCell.less
+++ b/src/StkTable/custom-cells/ChangeCell/ChangeCell.less
@@ -1,0 +1,34 @@
+.stk-change-cell {
+    // 默认（浅色）配色：涨红跌绿为 A 股习惯，颜色方向由组件按 colorReverse 决定
+    --stk-change-red: #e02020;
+    --stk-change-green: #00a870;
+    --stk-change-flat: #666;
+
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+
+    &--red {
+        color: var(--stk-change-red);
+    }
+
+    &--green {
+        color: var(--stk-change-green);
+    }
+
+    &--flat {
+        color: var(--stk-change-flat);
+    }
+
+    &__arrow {
+        font-size: 0.85em;
+        line-height: 1;
+    }
+}
+
+// 暗色主题下适当提亮，跟随表格根节点 .stk-table.dark
+.stk-table.dark .stk-change-cell {
+    --stk-change-red: #ff5c5c;
+    --stk-change-green: #26c281;
+    --stk-change-flat: #aaa;
+}

--- a/src/StkTable/custom-cells/ChangeCell/createChangeCell.ts
+++ b/src/StkTable/custom-cells/ChangeCell/createChangeCell.ts
@@ -1,0 +1,98 @@
+import type { CustomCellProps, StkTableColumn } from '../../types';
+import { defineComponent, h, markRaw } from 'vue';
+import { formatNumber, type FormatNumberOptions } from '../utils/formatNumber';
+
+/** createChangeCell 配置选项 */
+export interface CreateChangeCellOptions extends FormatNumberOptions {
+    /** 涨跌颜色是否反转：false=A股(涨红跌绿，默认)，true=国际(涨绿跌红) */
+    colorReverse?: boolean;
+    /** 是否显示涨跌箭头 ▲/▼，默认 false */
+    arrow?: boolean;
+    /** 自定义上涨颜色（覆盖默认配色，传入后不受 colorReverse 影响） */
+    riseColor?: string;
+    /** 自定义下跌颜色 */
+    fallColor?: string;
+    /** 自定义平盘颜色 */
+    flatColor?: string;
+}
+
+/** 涨跌方向：涨 / 跌 / 平（含空值） */
+type ChangeDir = 'rise' | 'fall' | 'flat';
+
+/** 根据原始值判断涨跌方向 */
+function resolveDir(rawValue: any): ChangeDir {
+    const num = rawValue === '' || rawValue == null ? NaN : Number(rawValue);
+    if (Number.isNaN(num) || num === 0) return 'flat';
+    return num > 0 ? 'rise' : 'fall';
+}
+
+/**
+ * 涨跌单元格工厂函数
+ *
+ * 在 {@link formatNumber} 的基础上叠加涨跌染色与箭头。染色按 `cellValue` 正负判断，
+ * 颜色方向可通过 `colorReverse` 切换（A股 / 国际），也可用 `riseColor` 等自定义。
+ * 数字对齐请在列配置上设置 `align: 'right'`。
+ *
+ * @param options 格式化 + 染色/箭头选项
+ * @returns
+ * - `ChangeCell` 组件构造函数，使用时需调用一次：`customCell: ChangeCell()`
+ * - `formatCopyText` 配套的复制文本格式化回调
+ *
+ * @example
+ * ```ts
+ * const { ChangeCell, formatCopyText } = createChangeCell({ decimals: 2, showSign: true, arrow: true });
+ * const ChangeCellComp = ChangeCell();
+ * const columns = [
+ *   { title: '涨跌额', dataIndex: 'change', align: 'right', customCell: ChangeCellComp, formatCopyText },
+ * ];
+ * ```
+ */
+export function createChangeCell(options: CreateChangeCellOptions = {}) {
+    const { colorReverse = false, arrow = false, riseColor, fallColor, flatColor } = options;
+
+    /** 单元格组件 - 用于 customCell */
+    function ChangeCell() {
+        return markRaw(
+            defineComponent({
+                // eslint-disable-next-line vue/require-prop-types
+                props: ['row', 'col', 'cellValue', 'rowIndex', 'colIndex', 'expanded', 'treeExpanded'],
+                setup(props: CustomCellProps<any>) {
+                    return () => {
+                        const raw = props.cellValue;
+                        const dir = resolveDir(raw);
+
+                        // 颜色 class：涨=红/跌=绿（colorReverse 时互换），平=中性
+                        let colorClass = 'stk-change-cell--flat';
+                        if (dir === 'rise') colorClass = colorReverse ? 'stk-change-cell--green' : 'stk-change-cell--red';
+                        else if (dir === 'fall') colorClass = colorReverse ? 'stk-change-cell--red' : 'stk-change-cell--green';
+
+                        // 自定义颜色（若传）直接内联覆盖
+                        const customColor = dir === 'rise' ? riseColor : dir === 'fall' ? fallColor : flatColor;
+
+                        // 箭头：涨 ▲ / 跌 ▼，平及空值不显示
+                        const arrowChar = arrow && dir !== 'flat' ? (dir === 'rise' ? '▲' : '▼') : '';
+
+                        return h(
+                            'span',
+                            {
+                                class: ['stk-change-cell', colorClass],
+                                style: customColor ? { color: customColor } : undefined,
+                            },
+                            [arrowChar ? h('span', { class: 'stk-change-cell__arrow' }, arrowChar) : null, formatNumber(raw, options)],
+                        );
+                    };
+                },
+            }),
+        );
+    }
+
+    /** 复制文本格式化：保证区域选取/复制得到的文本与展示一致 */
+    function formatCopyText(_row: Record<string, any>, _col: StkTableColumn<any>, rawValue: any) {
+        return formatNumber(rawValue, options);
+    }
+
+    return {
+        ChangeCell,
+        formatCopyText,
+    };
+}

--- a/src/StkTable/custom-cells/ChangeCell/index.ts
+++ b/src/StkTable/custom-cells/ChangeCell/index.ts
@@ -1,0 +1,4 @@
+export { createChangeCell } from './createChangeCell';
+export type { CreateChangeCellOptions } from './createChangeCell';
+
+import './ChangeCell.less';

--- a/src/StkTable/custom-cells/NumberCell/createNumberCell.ts
+++ b/src/StkTable/custom-cells/NumberCell/createNumberCell.ts
@@ -1,0 +1,51 @@
+import type { CustomCellProps, StkTableColumn } from '../../types';
+import { defineComponent, h, markRaw } from 'vue';
+import { formatNumber, type FormatNumberOptions } from '../utils/formatNumber';
+
+/** createNumberCell 配置选项（等同于格式化选项） */
+export interface CreateNumberCellOptions extends FormatNumberOptions {}
+
+/**
+ * 数字格式化单元格工厂函数
+ *
+ * 纯展示型单元格：将 `cellValue` 经 {@link formatNumber} 格式化为文本。
+ * 数字对齐请在列配置上设置 `align: 'right'`。
+ *
+ * @param options 格式化选项
+ * @returns
+ * - `NumberCell` 组件构造函数，使用时需调用一次：`customCell: NumberCell()`
+ * - `formatCopyText` 配套的复制文本格式化回调，挂到列上以保证复制内容与展示一致
+ *
+ * @example
+ * ```ts
+ * const { NumberCell, formatCopyText } = createNumberCell({ decimals: 2 });
+ * const NumberCellComp = NumberCell();
+ * const columns = [
+ *   { title: '现价', dataIndex: 'price', align: 'right', customCell: NumberCellComp, formatCopyText },
+ * ];
+ * ```
+ */
+export function createNumberCell(options?: CreateNumberCellOptions) {
+    /** 单元格组件 - 用于 customCell */
+    function NumberCell() {
+        return markRaw(
+            defineComponent({
+                // eslint-disable-next-line vue/require-prop-types
+                props: ['row', 'col', 'cellValue', 'rowIndex', 'colIndex', 'expanded', 'treeExpanded'],
+                setup(props: CustomCellProps<any>) {
+                    return () => h('span', { class: 'stk-number-cell' }, formatNumber(props.cellValue, options));
+                },
+            }),
+        );
+    }
+
+    /** 复制文本格式化：保证区域选取/复制得到的文本与展示一致 */
+    function formatCopyText(_row: Record<string, any>, _col: StkTableColumn<any>, rawValue: any) {
+        return formatNumber(rawValue, options);
+    }
+
+    return {
+        NumberCell,
+        formatCopyText,
+    };
+}

--- a/src/StkTable/custom-cells/NumberCell/index.ts
+++ b/src/StkTable/custom-cells/NumberCell/index.ts
@@ -1,0 +1,2 @@
+export { createNumberCell } from './createNumberCell';
+export type { CreateNumberCellOptions } from './createNumberCell';

--- a/src/StkTable/custom-cells/utils/formatNumber.ts
+++ b/src/StkTable/custom-cells/utils/formatNumber.ts
@@ -1,0 +1,108 @@
+/**
+ * 数字格式化选项
+ *
+ * NumberCell / ChangeCell 共享的格式化配置。
+ */
+export interface FormatNumberOptions {
+    /** 小数位数（四舍五入）。不传则不强制处理小数位 */
+    decimals?: number;
+    /** 是否使用千分位分隔符，默认 true */
+    thousands?: boolean;
+    /** 前缀，如 '¥'、'$' */
+    prefix?: string;
+    /** 后缀，如 '元'、'股' */
+    suffix?: string;
+    /** 正数是否强制显示 '+' 号，默认 false（负数始终带 '-'） */
+    showSign?: boolean;
+    /** 百分比模式：值 ×100 并追加 '%'，默认 false。与 abbr 互斥 */
+    percent?: boolean;
+    /** 单位缩放：'cn' = 万/亿，'en' = K/M/B。不传则不缩放。与 percent 互斥 */
+    abbr?: 'cn' | 'en';
+    /** 缩放后保留的小数位，默认 2 */
+    abbrDecimals?: number;
+    /** 空值(null/undefined/'')或非数字时的占位符，默认 '--' */
+    placeholder?: string;
+}
+
+/** 缩放单位阈值表（从大到小匹配） */
+const ABBR_UNITS: Record<'cn' | 'en', Array<[number, string]>> = {
+    cn: [
+        [1e8, '亿'],
+        [1e4, '万'],
+    ],
+    en: [
+        [1e9, 'B'],
+        [1e6, 'M'],
+        [1e3, 'K'],
+    ],
+};
+
+/**
+ * 给数字字符串的整数部分添加千分位分隔符。
+ * @param numStr 不含符号的正数字符串（可含小数部分）
+ */
+function addThousandsSeparator(numStr: string): string {
+    const [intPart, decPart] = numStr.split('.');
+    const withSep = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    return decPart != null ? `${withSep}.${decPart}` : withSep;
+}
+
+/**
+ * 数字格式化纯函数（NumberCell / ChangeCell 共享内核）。
+ *
+ * 处理管线：空值判断 → 取符号 → 百分比 → 单位缩放 → 小数位 → 千分位 → 拼装。
+ *
+ * @param value 原始值（数字或可转为数字的字符串）
+ * @param options 格式化选项
+ * @returns 格式化后的字符串；空值或非数字返回 placeholder
+ */
+export function formatNumber(value: unknown, options: FormatNumberOptions = {}): string {
+    const { decimals, thousands = true, prefix = '', suffix = '', showSign = false, percent = false, abbr, abbrDecimals, placeholder = '--' } = options;
+
+    // 空值判断（注意：Number('') === 0，必须先拦掉空字符串）
+    if (value === null || value === undefined || value === '') {
+        return placeholder;
+    }
+    const num = typeof value === 'number' ? value : Number(value);
+    if (Number.isNaN(num)) {
+        return placeholder;
+    }
+
+    // 符号基于原始值正负；0 不带符号
+    const sign = num < 0 ? '-' : showSign && num > 0 ? '+' : '';
+    let work = Math.abs(num);
+
+    // 百分比
+    if (percent) {
+        work = work * 100;
+    }
+
+    // 单位缩放（与百分比互斥）
+    let unit = '';
+    if (abbr && !percent) {
+        for (const [threshold, label] of ABBR_UNITS[abbr]) {
+            if (work >= threshold) {
+                work = work / threshold;
+                unit = label;
+                break;
+            }
+        }
+    }
+
+    // 小数位：缩放后优先 abbrDecimals，否则回落到 decimals，最终默认 2；未缩放时不强制
+    let fractionDigits: number | null;
+    if (unit) {
+        fractionDigits = abbrDecimals ?? decimals ?? 2;
+    } else {
+        fractionDigits = decimals ?? null;
+    }
+    let numStr = fractionDigits == null ? String(work) : work.toFixed(fractionDigits);
+
+    // 千分位
+    if (thousands) {
+        numStr = addThousandsSeparator(numStr);
+    }
+
+    const percentSuffix = percent ? '%' : '';
+    return `${prefix}${sign}${numStr}${unit}${percentSuffix}${suffix}`;
+}

--- a/src/StkTable/index.ts
+++ b/src/StkTable/index.ts
@@ -10,5 +10,11 @@ export { createEditableCell } from './custom-cells/EditableCell/index';
 export type { CreateEditableCellOptions } from './custom-cells/EditableCell/index';
 export { createCheckboxCell } from './custom-cells/CheckboxCell/index';
 export type { createCheckboxCellOptions } from './custom-cells/CheckboxCell/index';
+export { createNumberCell } from './custom-cells/NumberCell/index';
+export type { CreateNumberCellOptions } from './custom-cells/NumberCell/index';
+export { createChangeCell } from './custom-cells/ChangeCell/index';
+export type { CreateChangeCellOptions } from './custom-cells/ChangeCell/index';
+export { formatNumber } from './custom-cells/utils/formatNumber';
+export type { FormatNumberOptions } from './custom-cells/utils/formatNumber';
 
 import './style.less';

--- a/test/NumberChangeCellDemo.vue
+++ b/test/NumberChangeCellDemo.vue
@@ -1,0 +1,101 @@
+<script lang="ts" setup>
+import { ref } from 'vue';
+import { StkTable, StkTableColumn, createNumberCell, createChangeCell } from '../src/StkTable/index';
+
+/** 明暗主题切换（演示 ChangeCell 暗色配色） */
+const theme = ref<'light' | 'dark'>('light');
+/** 涨跌颜色方向：false=A股(涨红跌绿)，true=国际(涨绿跌红) */
+const colorReverse = ref(false);
+
+// ── 单元格工厂：每种格式建一个实例（与库内置工厂用法一致） ──
+const { NumberCell: PriceCtor, formatCopyText: priceCopy } = createNumberCell({ decimals: 2 });
+const priceCell = PriceCtor();
+
+const { NumberCell: VolCtor, formatCopyText: volCopy } = createNumberCell({ abbr: 'cn' });
+const volumeCell = VolCtor();
+
+const { NumberCell: AmountCtor, formatCopyText: amountCopy } = createNumberCell({ abbr: 'cn', prefix: '¥' });
+const amountCell = AmountCtor();
+
+// ChangeCell 依赖 colorReverse.value，用 getter 让切换即时生效
+function buildChangeCells() {
+    const { ChangeCell: ChangeCtor, formatCopyText: changeCopy } = createChangeCell({
+        decimals: 2,
+        showSign: true,
+        arrow: true,
+        colorReverse: colorReverse.value,
+    });
+    const { ChangeCell: PctCtor, formatCopyText: pctCopy } = createChangeCell({
+        percent: true,
+        decimals: 2,
+        showSign: true,
+        arrow: true,
+        colorReverse: colorReverse.value,
+    });
+    return {
+        changeCell: ChangeCtor(),
+        changeCopy,
+        pctCell: PctCtor(),
+        pctCopy,
+    };
+}
+
+const changeCells = ref(buildChangeCells());
+
+const columns = ref<StkTableColumn<any>[]>([]);
+
+function rebuildColumns() {
+    const { changeCell, changeCopy, pctCell, pctCopy } = changeCells.value;
+    columns.value = [
+        { title: '代码', dataIndex: 'code', width: 90, fixed: 'left' },
+        { title: '名称', dataIndex: 'name', width: 110, fixed: 'left' },
+        { title: '现价', dataIndex: 'price', width: 100, align: 'right', customCell: priceCell, formatCopyText: priceCopy },
+        { title: '涨跌额', dataIndex: 'change', width: 110, align: 'right', customCell: changeCell, formatCopyText: changeCopy },
+        { title: '涨跌幅', dataIndex: 'changePct', width: 110, align: 'right', customCell: pctCell, formatCopyText: pctCopy },
+        { title: '成交量', dataIndex: 'volume', width: 110, align: 'right', customCell: volumeCell, formatCopyText: volCopy },
+        { title: '成交额', dataIndex: 'amount', width: 130, align: 'right', customCell: amountCell, formatCopyText: amountCopy },
+    ];
+}
+rebuildColumns();
+
+function toggleColorReverse() {
+    colorReverse.value = !colorReverse.value;
+    changeCells.value = buildChangeCells();
+    rebuildColumns();
+}
+
+// ── 样例行情数据（含涨 / 跌 / 平 / 空值） ──
+const rawStocks = [
+    { code: '600519', name: '贵州茅台', price: 1685.32, change: 23.45, changePct: 0.0141, volume: 3456789, amount: 5823456789 },
+    { code: '000858', name: '五粮液', price: 152.18, change: -3.72, changePct: -0.0239, volume: 12345678, amount: 1878123456 },
+    { code: '300750', name: '宁德时代', price: 198.65, change: 8.9, changePct: 0.0469, volume: 23456789, amount: 4623456789 },
+    { code: '002594', name: '比亚迪', price: 245.0, change: 0, changePct: 0, volume: 8765432, amount: 2147000000 },
+    { code: '601318', name: '中国平安', price: 48.76, change: -1.23, changePct: -0.0246, volume: 45678901, amount: 2223456789 },
+    { code: '600036', name: '招商银行', price: 36.42, change: 0.58, changePct: 0.0162, volume: 34567890, amount: 1258765432 },
+    { code: '000001', name: '平安银行', price: 11.85, change: -0.09, changePct: -0.0075, volume: 56789012, amount: 673456789 },
+    { code: '688981', name: '中芯国际', price: 52.3, change: 2.15, changePct: 0.0429, volume: 18765432, amount: 981234567 },
+    { code: '600900', name: '长江电力', price: 27.66, change: null, changePct: null, volume: 9876543, amount: 273123456 },
+    { code: '601899', name: '紫金矿业', price: 15.42, change: 0.33, changePct: 0.0219, volume: 67890123, amount: 1046789012 },
+];
+
+const dataSource = ref(rawStocks.map((s, i) => ({ id: i, ...s })));
+</script>
+
+<template>
+    <div style="width: 100%; padding: 12px">
+        <h3>NumberCell / ChangeCell 演示（金融行情）</h3>
+        <div style="margin-bottom: 8px; display: flex; gap: 8px">
+            <button @click="theme = theme === 'light' ? 'dark' : 'light'">切换主题：{{ theme }}</button>
+            <button @click="toggleColorReverse">涨跌配色：{{ colorReverse ? '国际(涨绿跌红)' : 'A股(涨红跌绿)' }}</button>
+        </div>
+        <StkTable
+            row-key="id"
+            :theme="theme"
+            :columns="columns"
+            :data-source="dataSource"
+            virtual
+            style="height: 360px"
+            fixed-col-shadow
+        ></StkTable>
+    </div>
+</template>

--- a/test/formatNumber.test.ts
+++ b/test/formatNumber.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { formatNumber } from '../src/StkTable/custom-cells/utils/formatNumber';
+
+describe('formatNumber', () => {
+    describe('空值与非数字', () => {
+        it('null/undefined/空字符串返回默认占位符 --', () => {
+            expect(formatNumber(null)).toBe('--');
+            expect(formatNumber(undefined)).toBe('--');
+            expect(formatNumber('')).toBe('--');
+        });
+        it('非数字字符串返回占位符', () => {
+            expect(formatNumber('abc')).toBe('--');
+        });
+        it('可自定义占位符', () => {
+            expect(formatNumber(null, { placeholder: 'N/A' })).toBe('N/A');
+        });
+        it('0 正常格式化而非占位符', () => {
+            expect(formatNumber(0)).toBe('0');
+        });
+    });
+
+    describe('小数位与千分位', () => {
+        it('默认开启千分位', () => {
+            expect(formatNumber(1234567)).toBe('1,234,567');
+        });
+        it('保留小数位并四舍五入', () => {
+            expect(formatNumber(3.14159, { decimals: 2 })).toBe('3.14');
+            expect(formatNumber(2.71828, { decimals: 2 })).toBe('2.72');
+        });
+        it('可关闭千分位', () => {
+            expect(formatNumber(1234567, { thousands: false })).toBe('1234567');
+        });
+        it('千分位与小数位组合', () => {
+            expect(formatNumber(1234567.891, { decimals: 2 })).toBe('1,234,567.89');
+        });
+        it('负数', () => {
+            expect(formatNumber(-1234.5, { decimals: 1 })).toBe('-1,234.5');
+        });
+    });
+
+    describe('符号与百分比', () => {
+        it('showSign 正数加 +', () => {
+            expect(formatNumber(5, { showSign: true })).toBe('+5');
+        });
+        it('showSign 不影响负数与 0', () => {
+            expect(formatNumber(-5, { showSign: true })).toBe('-5');
+            expect(formatNumber(0, { showSign: true })).toBe('0');
+        });
+        it('percent 乘 100 加 %', () => {
+            expect(formatNumber(0.05, { percent: true, decimals: 2 })).toBe('5.00%');
+        });
+        it('percent 结合 showSign', () => {
+            expect(formatNumber(0.05, { percent: true, decimals: 2, showSign: true })).toBe('+5.00%');
+        });
+    });
+
+    describe('前后缀', () => {
+        it('prefix / suffix', () => {
+            expect(formatNumber(1234.5, { prefix: '¥', decimals: 2 })).toBe('¥1,234.50');
+            expect(formatNumber(100, { suffix: '元' })).toBe('100元');
+        });
+        it('prefix 位于符号之前', () => {
+            expect(formatNumber(-100, { prefix: '$' })).toBe('$-100');
+        });
+    });
+
+    describe('单位缩放 abbr=cn', () => {
+        it('万', () => {
+            expect(formatNumber(12345, { abbr: 'cn' })).toBe('1.23万');
+        });
+        it('亿', () => {
+            expect(formatNumber(123456789, { abbr: 'cn' })).toBe('1.23亿');
+        });
+        it('不足万不缩放', () => {
+            expect(formatNumber(9999, { abbr: 'cn' })).toBe('9,999');
+        });
+        it('abbrDecimals 控制缩放后小数位', () => {
+            expect(formatNumber(12345, { abbr: 'cn', abbrDecimals: 1 })).toBe('1.2万');
+        });
+        it('负数缩放', () => {
+            expect(formatNumber(-12345, { abbr: 'cn' })).toBe('-1.23万');
+        });
+    });
+
+    describe('单位缩放 abbr=en', () => {
+        it('K / M / B', () => {
+            expect(formatNumber(1500, { abbr: 'en' })).toBe('1.50K');
+            expect(formatNumber(2500000, { abbr: 'en' })).toBe('2.50M');
+            expect(formatNumber(3200000000, { abbr: 'en' })).toBe('3.20B');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Adds two display-oriented built-in custom-cell extensions, following the existing `createXxxCell` factory pattern.

- **formatNumber** — shared pure-function core: decimals (rounding), thousands separator, prefix/suffix, forced sign, percent, cn/en unit abbreviation (万/亿, K/M/B), empty-value placeholder. Exported for reuse (footer totals, tooltips, etc.).
- **createNumberCell** — formats a cell value as text; also returns a matching `formatCopyText` so area-selection / copy stays consistent with the display.
- **createChangeCell** — builds on `formatNumber` and adds rise/fall coloring + ▲/▼ arrows. Coloring follows the value sign; `colorReverse` switches A-share (rise red / fall green) ↔ international (rise green / fall red); custom `riseColor` / `fallColor` / `flatColor` supported; colors adapt to the table's dark theme automatically.
- Exports `createNumberCell`, `createChangeCell`, `formatNumber` and their option types from the package entry.

## Docs
- New pages `number-cell.md` / `change-cell.md` in zh / en / ja / ko, plus sidebar entries.
- `docs-demo` examples for both cells and 5 new i18n terms (price / volume / turnover / change / changePercent) across all four locales.

## Test plan
- `test/formatNumber.test.ts` covers decimals & rounding, thousands, forced sign, percent, prefix/suffix, cn/en abbreviation (incl. threshold boundaries), negatives and empty/NaN values (28 assertions).
- New `src` modules and both `docs-demo` examples verified to transpile without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)