### PR TITLE
feat: align scrollTo with Naive UI virtual list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ## 1.2.0-beta.1
 * Feature
-  - feat: align the exposed `scrollTo` method with Naive UI Virtual List. It now supports native `(x, y)` coordinates and `{ left, top }`, row `{ index }`, row `{ key }`, and `{ position: 'top' | 'bottom' }` options, plus `behavior` and index/key `debounce` semantics.
+  - feat: align the exposed `scrollTo` method with Naive UI Virtual List. It now supports native `(x, y)` coordinates and `{ left, top }`, row `{ index }`, row `{ key }`, and `{ position: 'top' | 'bottom' }` options, plus `behavior` and index/key `debounce` semantics. The package root now exports the public `ScrollTo`, mutually exclusive `ScrollToOptions`, and `CommonScrollToOptions` types.
   - feat: add instance method `clearMergeCellsCache` to clear the `mergeCells` result cache and force recalculation. The cache is only auto-cleared when `dataSource` / `columns` change; call this method after mutating row fields in place (row reference unchanged) that `mergeCells` depends on.
   - feat: `mergeCells` now supports huge `rowspan` (e.g. thousands of rows) in `virtual` mode. Rows covered by a rowspan anchor above the viewport are compressed into placeholder cells/rows instead of being fully rendered, so the DOM node count stays proportional to the viewport size.
   - feat: `mergeCells` now supports huge `colspan` (e.g. merging 150 columns) in `virtualX` mode. When the anchor column of a merged cell scrolls out of the viewport, the visible column range is expanded so the merged cell is fully rendered; in the expanded area, non-merged cells on the left are compressed into a single placeholder `td` with `colspan`, and the right part is not rendered at all (tbody only; thead keeps the full expanded range).
@@ -9,6 +9,7 @@
   - perf: reduced DOM node count in merged scenarios and eliminated the double rendering of merged rows.
   - perf: `virtualScroll` / `virtualScrollX` switched from `ref` to `shallowRef` with explicit `triggerRef` at each write boundary, so Vue is notified once per scroll frame instead of on every property assignment, eliminating deep Proxy overhead in the hot scroll path.
 * Bugfix:
+  - fix: use measured/expected row heights and sticky-footer geometry consistently for experimental Y-scroll clamping and custom scrollbar metrics.
   - fix: remove `contain: paint` from tbody `tr` — it clipped cells to a zero-height row box in table layout, causing cells to disappear.
 * Breaking Changes
   - `scrollTo(number, number)` now follows the native `(x, y)` / `(left, top)` order instead of the previous `(top, left)` order. Use `scrollTo({ top, left })` to avoid positional ambiguity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 ## 1.2.0-beta.1
 * Feature
+  - feat: align the exposed `scrollTo` method with Naive UI Virtual List. It now supports native `(x, y)` coordinates and `{ left, top }`, row `{ index }`, row `{ key }`, and `{ position: 'top' | 'bottom' }` options, plus `behavior` and index/key `debounce` semantics.
   - feat: add instance method `clearMergeCellsCache` to clear the `mergeCells` result cache and force recalculation. The cache is only auto-cleared when `dataSource` / `columns` change; call this method after mutating row fields in place (row reference unchanged) that `mergeCells` depends on.
   - feat: `mergeCells` now supports huge `rowspan` (e.g. thousands of rows) in `virtual` mode. Rows covered by a rowspan anchor above the viewport are compressed into placeholder cells/rows instead of being fully rendered, so the DOM node count stays proportional to the viewport size.
   - feat: `mergeCells` now supports huge `colspan` (e.g. merging 150 columns) in `virtualX` mode. When the anchor column of a merged cell scrolls out of the viewport, the visible column range is expanded so the merged cell is fully rendered; in the expanded area, non-merged cells on the left are compressed into a single placeholder `td` with `colspan`, and the right part is not rendered at all (tbody only; thead keeps the full expanded range).
@@ -9,6 +10,8 @@
   - perf: `virtualScroll` / `virtualScrollX` switched from `ref` to `shallowRef` with explicit `triggerRef` at each write boundary, so Vue is notified once per scroll frame instead of on every property assignment, eliminating deep Proxy overhead in the hot scroll path.
 * Bugfix:
   - fix: remove `contain: paint` from tbody `tr` — it clipped cells to a zero-height row box in table layout, causing cells to disappear.
+* Breaking Changes
+  - `scrollTo(number, number)` now follows the native `(x, y)` / `(left, top)` order instead of the previous `(top, left)` order. Use `scrollTo({ top, left })` to avoid positional ambiguity.
 
 ## 1.1.0
 * Feature

--- a/docs-src/en/main/api/expose.md
+++ b/docs-src/en/main/api/expose.md
@@ -175,30 +175,65 @@ Reset sort state
 Scroll the table by coordinates, row index, row key, or boundary. The API shape matches native `Element.scrollTo` and Naive UI Virtual List.
 
 ```ts
+interface CommonScrollToOptions {
+    behavior?: ScrollBehavior
+    debounce?: boolean
+}
+
+type ScrollToOptions = CommonScrollToOptions & (
+    | {
+          left: number
+          top?: number
+          index?: never
+          key?: never
+          position?: never
+      }
+    | {
+          left?: number
+          top: number
+          index?: never
+          key?: never
+          position?: never
+      }
+    | {
+          left?: never
+          top?: never
+          index: number
+          key?: never
+          position?: never
+      }
+    | {
+          left?: never
+          top?: never
+          index?: never
+          key: string | number
+          position?: never
+      }
+    | {
+          left?: never
+          top?: never
+          index?: never
+          key?: never
+          position: 'top' | 'bottom'
+      }
+)
+
 interface ScrollTo {
     (x: number, y: number): void
-    (options: {
-        left?: number
-        top?: number
-        behavior?: ScrollBehavior
-        debounce?: boolean
-    }): void
-    (options: {
-        index: number
-        behavior?: ScrollBehavior
-        debounce?: boolean
-    }): void
-    (options: {
-        key: string | number
-        behavior?: ScrollBehavior
-        debounce?: boolean
-    }): void
-    (options: {
-        position: 'top' | 'bottom'
-        behavior?: ScrollBehavior
-        debounce?: boolean
-    }): void
+    (options: ScrollToOptions): void
 }
+```
+
+`ScrollTo`, `ScrollToOptions`, and `CommonScrollToOptions` are public types exported from the package root. `ScrollToOptions` is a mutually exclusive union: coordinate targets require at least `left` or `top`, while other targets allow exactly one of `index`, `key`, or `position`. Empty objects and mixed targets fail TypeScript compilation.
+
+```ts
+import type { CommonScrollToOptions, ScrollTo, ScrollToOptions } from 'stk-table-vue'
+
+const common: CommonScrollToOptions = { behavior: 'smooth', debounce: false }
+const target: ScrollToOptions = { key: orderId, ...common }
+const scroll: ScrollTo = tableRef.value!.scrollTo
+
+scroll(target)
 ```
 
 - In `(x, y)`, `x` is the horizontal `left` coordinate and `y` is the vertical `top` coordinate.

--- a/docs-src/en/main/api/expose.md
+++ b/docs-src/en/main/api/expose.md
@@ -172,16 +172,63 @@ function setSorter(
 Reset sort state
 
 ### scrollTo
-Scroll to specified position
+Scroll the table by coordinates, row index, row key, or boundary. The API shape matches native `Element.scrollTo` and Naive UI Virtual List.
 
 ```ts
-/**
- * Set scrollbar position
- * @param top Set to null to not change position
- * @param left Set to null to not change position
- */
-function scrollTo(top: number | null = 0, left: number | null = 0)
+interface ScrollTo {
+    (x: number, y: number): void
+    (options: {
+        left?: number
+        top?: number
+        behavior?: ScrollBehavior
+        debounce?: boolean
+    }): void
+    (options: {
+        index: number
+        behavior?: ScrollBehavior
+        debounce?: boolean
+    }): void
+    (options: {
+        key: string | number
+        behavior?: ScrollBehavior
+        debounce?: boolean
+    }): void
+    (options: {
+        position: 'top' | 'bottom'
+        behavior?: ScrollBehavior
+        debounce?: boolean
+    }): void
+}
 ```
+
+- In `(x, y)`, `x` is the horizontal `left` coordinate and `y` is the vertical `top` coordinate.
+- `index` is a zero-based row index in the table's current display order, after sorting, filtering, or tree flattening.
+- `key` uses `props.rowKey` to locate a row in the currently visible data; a missing key is a no-op.
+- `debounce` applies to `index` / `key` and defaults to `true`: do nothing when the row is fully visible, otherwise scroll the minimum distance needed to reveal it. Set it to `false` to always align the row with the top of the table body.
+- `behavior` matches native `ScrollToOptions.behavior`: `'auto'`, `'instant'`, or `'smooth'`.
+- `position` scrolls to the top or bottom and, like Naive UI, also resets the horizontal position.
+
+```ts
+// Scroll to row 101, unless it is already visible
+tableRef.value?.scrollTo({ index: 100 })
+
+// Locate by rowKey and smoothly align the row with the body top
+tableRef.value?.scrollTo({ key: orderId, behavior: 'smooth', debounce: false })
+
+// Change only the vertical coordinate
+tableRef.value?.scrollTo({ top: 600 })
+
+// Scroll to the table bottom
+tableRef.value?.scrollTo({ position: 'bottom' })
+```
+
+::: warning Compatibility change
+The numeric overload changed from `(top, left)` to the native `(x, y)` order, meaning `(left, top)`. Change old `scrollTo(top, left)` calls to `scrollTo(left, top)`, or use the unambiguous `scrollTo({ top, left })` form.
+:::
+
+::: tip
+In variable-row-height mode, `index` / `key` use measured heights and values supplied through `setAutoHeight`. Unmeasured rows use `autoRowHeight.expectedHeight`, then fall back to `rowHeight`.
+:::
 
 ### getTableData
 Get table data, returns array in current table sort order
@@ -299,4 +346,3 @@ Set filter status(Beta). Triggers the `filter-change` event after setting.
  */
 function setFilter(status: Record<UniqKey, FilterStatus> | null, option?: { remote?: boolean; silent?: boolean })
 ```
-

--- a/docs-src/en/main/table/advanced/virtual.md
+++ b/docs-src/en/main/table/advanced/virtual.md
@@ -64,6 +64,17 @@ initVirtualScroll(height?: number)
 <StkTable :autoResize="false"></StkTable>
 ```
 
+## Programmatic Scrolling
+
+The `scrollTo` instance method can locate coordinates, a row by its current display `index` / `rowKey`, or the table top or bottom, with optional smooth scrolling.
+
+```ts
+tableRef.value?.scrollTo({ index: 100 })
+tableRef.value?.scrollTo({ key: orderId, behavior: 'smooth' })
+tableRef.value?.scrollTo({ position: 'bottom' })
+```
+
+See the [`scrollTo` instance method](/en/main/api/expose#scrollto) for the complete signatures, `debounce` behavior, and numeric-overload migration note.
+
 ## Single Column List
 Please refer to [Virtual Single List](/en/demos/virtual-list.html)
-

--- a/docs-src/ja/main/api/expose.md
+++ b/docs-src/ja/main/api/expose.md
@@ -172,16 +172,63 @@ function setSorter(
 排序状態をリセット
 
 ### scrollTo
-指定位置までスクロール
+座標、行インデックス、行 key、または境界を指定してテーブルをスクロールします。API 形式はネイティブの `Element.scrollTo` および Naive UI Virtual List と同じです。
 
 ```ts
-/**
- * スクロールバー位置を設定
- * @param top nullに設定して位置を変更しない
- * @param left nullに設定して位置を変更しない
- */
-function scrollTo(top: number | null = 0, left: number | null = 0)
+interface ScrollTo {
+    (x: number, y: number): void
+    (options: {
+        left?: number
+        top?: number
+        behavior?: ScrollBehavior
+        debounce?: boolean
+    }): void
+    (options: {
+        index: number
+        behavior?: ScrollBehavior
+        debounce?: boolean
+    }): void
+    (options: {
+        key: string | number
+        behavior?: ScrollBehavior
+        debounce?: boolean
+    }): void
+    (options: {
+        position: 'top' | 'bottom'
+        behavior?: ScrollBehavior
+        debounce?: boolean
+    }): void
+}
 ```
+
+- `(x, y)` の `x` は横方向の `left`、`y` は縦方向の `top` です。
+- `index` は、ソート、フィルター、ツリー展開後の現在の表示順における 0 始まりの行インデックスです。
+- `key` は `props.rowKey` を使用して現在表示されているデータの行を検索します。見つからない場合はスクロールしません。
+- `debounce` は `index` / `key` にのみ適用され、既定値は `true` です。行が完全に表示されていれば何もせず、表示範囲外なら必要最小限だけスクロールします。`false` にすると常に行をテーブル本体の上端に揃えます。
+- `behavior` はネイティブの `ScrollToOptions.behavior` と同じで、`'auto'`、`'instant'`、`'smooth'` を指定できます。
+- `position` は上端または下端へ移動し、Naive UI と同様に横方向も先頭へ戻します。
+
+```ts
+// 101 行目へ移動（すでに表示されている場合は位置を維持）
+tableRef.value?.scrollTo({ index: 100 })
+
+// rowKey で検索し、行を本体上端へ滑らかに揃える
+tableRef.value?.scrollTo({ key: orderId, behavior: 'smooth', debounce: false })
+
+// 横方向を変えずに縦座標だけ変更
+tableRef.value?.scrollTo({ top: 600 })
+
+// テーブルの下端へ移動
+tableRef.value?.scrollTo({ position: 'bottom' })
+```
+
+::: warning 互換性の変更
+数値オーバーロードは旧 `(top, left)` からネイティブと同じ `(x, y)`、つまり `(left, top)` に変更されました。既存の `scrollTo(top, left)` は `scrollTo(left, top)` に変更するか、曖昧さのない `scrollTo({ top, left })` を使用してください。
+:::
+
+::: tip
+可変行高モードでは、`index` / `key` は測定済みの行高と `setAutoHeight` で設定した値を使用します。未測定の行は `autoRowHeight.expectedHeight`、次に `rowHeight` を使用します。
+:::
 
 ### getTableData
 テーブルデータを取得、現在のテーブル排序順序の配列を返します
@@ -299,4 +346,3 @@ function copySelectedArea(): string
  */
 function setFilter(status: Record<UniqKey, FilterStatus> | null, option?: { remote?: boolean; silent?: boolean })
 ```
-

--- a/docs-src/ja/main/api/expose.md
+++ b/docs-src/ja/main/api/expose.md
@@ -175,30 +175,65 @@ function setSorter(
 座標、行インデックス、行 key、または境界を指定してテーブルをスクロールします。API 形式はネイティブの `Element.scrollTo` および Naive UI Virtual List と同じです。
 
 ```ts
+interface CommonScrollToOptions {
+    behavior?: ScrollBehavior
+    debounce?: boolean
+}
+
+type ScrollToOptions = CommonScrollToOptions & (
+    | {
+          left: number
+          top?: number
+          index?: never
+          key?: never
+          position?: never
+      }
+    | {
+          left?: number
+          top: number
+          index?: never
+          key?: never
+          position?: never
+      }
+    | {
+          left?: never
+          top?: never
+          index: number
+          key?: never
+          position?: never
+      }
+    | {
+          left?: never
+          top?: never
+          index?: never
+          key: string | number
+          position?: never
+      }
+    | {
+          left?: never
+          top?: never
+          index?: never
+          key?: never
+          position: 'top' | 'bottom'
+      }
+)
+
 interface ScrollTo {
     (x: number, y: number): void
-    (options: {
-        left?: number
-        top?: number
-        behavior?: ScrollBehavior
-        debounce?: boolean
-    }): void
-    (options: {
-        index: number
-        behavior?: ScrollBehavior
-        debounce?: boolean
-    }): void
-    (options: {
-        key: string | number
-        behavior?: ScrollBehavior
-        debounce?: boolean
-    }): void
-    (options: {
-        position: 'top' | 'bottom'
-        behavior?: ScrollBehavior
-        debounce?: boolean
-    }): void
+    (options: ScrollToOptions): void
 }
+```
+
+`ScrollTo`、`ScrollToOptions`、`CommonScrollToOptions` は、いずれもパッケージのルートからエクスポートされる公開型です。`ScrollToOptions` は排他的 union です。座標形式には `left` または `top` の少なくとも一方が必要で、その他の形式では `index`、`key`、`position` のいずれか一つだけを指定できます。空オブジェクトや複数ターゲットの組み合わせは TypeScript のコンパイルエラーになります。
+
+```ts
+import type { CommonScrollToOptions, ScrollTo, ScrollToOptions } from 'stk-table-vue'
+
+const common: CommonScrollToOptions = { behavior: 'smooth', debounce: false }
+const target: ScrollToOptions = { key: orderId, ...common }
+const scroll: ScrollTo = tableRef.value!.scrollTo
+
+scroll(target)
 ```
 
 - `(x, y)` の `x` は横方向の `left`、`y` は縦方向の `top` です。

--- a/docs-src/ja/main/table/advanced/virtual.md
+++ b/docs-src/ja/main/table/advanced/virtual.md
@@ -64,5 +64,17 @@ initVirtualScroll(height?: number)
 <StkTable :autoResize="false"></StkTable>
 ```
 
+## プログラムによるスクロール
+
+インスタンスメソッド `scrollTo` は、座標、現在の表示行の `index` / `rowKey`、またはテーブルの上端・下端へ移動でき、スムーズスクロールにも対応します。
+
+```ts
+tableRef.value?.scrollTo({ index: 100 })
+tableRef.value?.scrollTo({ key: orderId, behavior: 'smooth' })
+tableRef.value?.scrollTo({ position: 'bottom' })
+```
+
+完全なシグネチャ、`debounce` の動作、数値オーバーロードの移行方法は [`scrollTo` インスタンスメソッド](/ja/main/api/expose#scrollto) を参照してください。
+
 ## 単位列リスト
 [仮想単位リスト](/ja/demos/virtual-list.html) を参照してください。

--- a/docs-src/ko/main/api/expose.md
+++ b/docs-src/ko/main/api/expose.md
@@ -174,30 +174,65 @@ function setSorter(
 좌표, 행 인덱스, 행 key 또는 경계를 기준으로 테이블을 스크롤합니다. API 형식은 네이티브 `Element.scrollTo` 및 Naive UI Virtual List와 같습니다.
 
 ```ts
+interface CommonScrollToOptions {
+    behavior?: ScrollBehavior
+    debounce?: boolean
+}
+
+type ScrollToOptions = CommonScrollToOptions & (
+    | {
+          left: number
+          top?: number
+          index?: never
+          key?: never
+          position?: never
+      }
+    | {
+          left?: number
+          top: number
+          index?: never
+          key?: never
+          position?: never
+      }
+    | {
+          left?: never
+          top?: never
+          index: number
+          key?: never
+          position?: never
+      }
+    | {
+          left?: never
+          top?: never
+          index?: never
+          key: string | number
+          position?: never
+      }
+    | {
+          left?: never
+          top?: never
+          index?: never
+          key?: never
+          position: 'top' | 'bottom'
+      }
+)
+
 interface ScrollTo {
     (x: number, y: number): void
-    (options: {
-        left?: number
-        top?: number
-        behavior?: ScrollBehavior
-        debounce?: boolean
-    }): void
-    (options: {
-        index: number
-        behavior?: ScrollBehavior
-        debounce?: boolean
-    }): void
-    (options: {
-        key: string | number
-        behavior?: ScrollBehavior
-        debounce?: boolean
-    }): void
-    (options: {
-        position: 'top' | 'bottom'
-        behavior?: ScrollBehavior
-        debounce?: boolean
-    }): void
+    (options: ScrollToOptions): void
 }
+```
+
+`ScrollTo`, `ScrollToOptions`, `CommonScrollToOptions`는 모두 패키지 루트에서 내보내는 공개 타입입니다. `ScrollToOptions`는 상호 배타적인 union입니다. 좌표 형식에는 `left` 또는 `top` 중 하나 이상이 필요하고, 다른 형식에는 `index`, `key`, `position` 중 정확히 하나만 사용할 수 있습니다. 빈 객체나 여러 대상을 섞은 값은 TypeScript 컴파일 오류가 됩니다.
+
+```ts
+import type { CommonScrollToOptions, ScrollTo, ScrollToOptions } from 'stk-table-vue'
+
+const common: CommonScrollToOptions = { behavior: 'smooth', debounce: false }
+const target: ScrollToOptions = { key: orderId, ...common }
+const scroll: ScrollTo = tableRef.value!.scrollTo
+
+scroll(target)
 ```
 
 - `(x, y)`에서 `x`는 가로 `left`, `y`는 세로 `top` 좌표입니다.

--- a/docs-src/ko/main/api/expose.md
+++ b/docs-src/ko/main/api/expose.md
@@ -171,16 +171,63 @@ function setSorter(
 정렬 상태 초기화
 
 ### scrollTo
-지정 위치로 스크롤
+좌표, 행 인덱스, 행 key 또는 경계를 기준으로 테이블을 스크롤합니다. API 형식은 네이티브 `Element.scrollTo` 및 Naive UI Virtual List와 같습니다.
 
 ```ts
-/**
- * 스크롤바 위치 설정
- * @param top null 설정 시 위치 변경 안함
- * @param left null 설정 시 위치 변경 안함
- */
-function scrollTo(top: number | null = 0, left: number | null = 0)
+interface ScrollTo {
+    (x: number, y: number): void
+    (options: {
+        left?: number
+        top?: number
+        behavior?: ScrollBehavior
+        debounce?: boolean
+    }): void
+    (options: {
+        index: number
+        behavior?: ScrollBehavior
+        debounce?: boolean
+    }): void
+    (options: {
+        key: string | number
+        behavior?: ScrollBehavior
+        debounce?: boolean
+    }): void
+    (options: {
+        position: 'top' | 'bottom'
+        behavior?: ScrollBehavior
+        debounce?: boolean
+    }): void
+}
 ```
+
+- `(x, y)`에서 `x`는 가로 `left`, `y`는 세로 `top` 좌표입니다.
+- `index`는 정렬, 필터링 또는 트리 펼침이 적용된 현재 표시 순서의 0부터 시작하는 행 인덱스입니다.
+- `key`는 `props.rowKey`를 사용하여 현재 표시 데이터의 행을 찾습니다. 찾지 못하면 스크롤하지 않습니다.
+- `debounce`는 `index` / `key`에만 적용되며 기본값은 `true`입니다. 행이 완전히 보이면 이동하지 않고, 보이지 않으면 필요한 최소 거리만 스크롤합니다. `false`이면 항상 행을 테이블 본문 상단에 맞춥니다.
+- `behavior`는 네이티브 `ScrollToOptions.behavior`와 동일하며 `'auto'`, `'instant'`, `'smooth'`를 사용할 수 있습니다.
+- `position`은 상단 또는 하단으로 이동하고 Naive UI와 동일하게 가로 위치도 시작점으로 되돌립니다.
+
+```ts
+// 101번째 행으로 이동하며, 이미 보이는 경우 현재 위치 유지
+tableRef.value?.scrollTo({ index: 100 })
+
+// rowKey로 찾고 행을 본문 상단에 부드럽게 맞춤
+tableRef.value?.scrollTo({ key: orderId, behavior: 'smooth', debounce: false })
+
+// 가로 위치는 유지하고 세로 좌표만 변경
+tableRef.value?.scrollTo({ top: 600 })
+
+// 테이블 하단으로 이동
+tableRef.value?.scrollTo({ position: 'bottom' })
+```
+
+::: warning 호환성 변경
+숫자 오버로드가 기존 `(top, left)`에서 네이티브와 같은 `(x, y)`, 즉 `(left, top)` 순서로 변경되었습니다. 기존 `scrollTo(top, left)` 호출은 `scrollTo(left, top)`으로 바꾸거나 모호하지 않은 `scrollTo({ top, left })` 형식을 사용하세요.
+:::
+
+::: tip
+가변 행 높이 모드에서 `index` / `key`는 측정된 높이와 `setAutoHeight`로 설정된 값을 사용합니다. 측정되지 않은 행은 `autoRowHeight.expectedHeight`, 그다음 `rowHeight`를 사용합니다.
+:::
 
 ### getTableData
 테이블 데이터 가져오기, 현재 테이블 정렬 순서의 배열 반환
@@ -298,4 +345,3 @@ function copySelectedArea(): string
  */
 function setFilter(status: Record<UniqKey, FilterStatus> | null, option?: { remote?: boolean; silent?: boolean })
 ```
-

--- a/docs-src/ko/main/table/advanced/virtual.md
+++ b/docs-src/ko/main/table/advanced/virtual.md
@@ -64,5 +64,17 @@ initVirtualScroll(height?: number)
 <StkTable :autoResize="false"></StkTable>
 ```
 
+## 프로그래밍 방식 스크롤
+
+인스턴스 메서드 `scrollTo`는 좌표, 현재 표시 행의 `index` / `rowKey`, 테이블의 상단 또는 하단으로 이동할 수 있으며 부드러운 스크롤도 지원합니다.
+
+```ts
+tableRef.value?.scrollTo({ index: 100 })
+tableRef.value?.scrollTo({ key: orderId, behavior: 'smooth' })
+tableRef.value?.scrollTo({ position: 'bottom' })
+```
+
+전체 시그니처, `debounce` 동작 및 숫자 오버로드 마이그레이션은 [`scrollTo` 인스턴스 메서드](/ko/main/api/expose#scrollto)를 참고하세요.
+
 ## 단일 열 리스트
 자세한 내용은 [가상 단일 열 리스트](/ko/demos/virtual-list.html)를 참고하세요.

--- a/docs-src/main/api/expose.md
+++ b/docs-src/main/api/expose.md
@@ -171,16 +171,63 @@ function setSorter(
 重置排序状态
 
 ### scrollTo
-滚动到指定位置
+按坐标、行索引、行 key 或边界滚动表格。接口形式与原生 `Element.scrollTo` / Naive UI Virtual List 一致。
 
 ```ts
-/**
- * 设置滚动条位置
- * @param top 设置null则不改变位置
- * @param left 设置null则不改变位置
- */
-function scrollTo(top: number | null = 0, left: number | null = 0)
+interface ScrollTo {
+    (x: number, y: number): void
+    (options: {
+        left?: number
+        top?: number
+        behavior?: ScrollBehavior
+        debounce?: boolean
+    }): void
+    (options: {
+        index: number
+        behavior?: ScrollBehavior
+        debounce?: boolean
+    }): void
+    (options: {
+        key: string | number
+        behavior?: ScrollBehavior
+        debounce?: boolean
+    }): void
+    (options: {
+        position: 'top' | 'bottom'
+        behavior?: ScrollBehavior
+        debounce?: boolean
+    }): void
+}
 ```
+
+- `(x, y)` 中 `x` 表示横向 `left`，`y` 表示纵向 `top`。
+- `index` 是当前表格展示顺序中的零基行索引（包含排序、筛选或树形数据展开后的结果）。
+- `key` 使用 `props.rowKey` 定位当前可见数据中的行；未找到时不滚动。
+- `debounce` 仅用于 `index` / `key`，默认为 `true`：目标行已完全可见时不滚动，否则以最小距离使其可见；设为 `false` 时总是将目标行对齐到表体顶部。
+- `behavior` 与原生 `ScrollToOptions.behavior` 相同，可传入 `'auto'`、`'instant'` 或 `'smooth'`。
+- `position` 滚动到顶部或底部，并像 Naive UI 一样同时回到横向起点。
+
+```ts
+// 滚动到第 101 行；若已经可见则保持当前位置
+tableRef.value?.scrollTo({ index: 100 })
+
+// 通过 rowKey 定位，并平滑对齐到表体顶部
+tableRef.value?.scrollTo({ key: orderId, behavior: 'smooth', debounce: false })
+
+// 只修改纵向坐标，不改变横向位置
+tableRef.value?.scrollTo({ top: 600 })
+
+// 滚动到表格底部
+tableRef.value?.scrollTo({ position: 'bottom' })
+```
+
+::: warning 兼容性变化
+数值重载已从旧版 `(top, left)` 调整为与原生 API 一致的 `(x, y)`（即 `(left, top)`）。旧代码 `scrollTo(top, left)` 应改为 `scrollTo(left, top)`，或使用无歧义的 `scrollTo({ top, left })`。
+:::
+
+::: tip
+在可变行高模式下，`index` / `key` 会使用已测量或通过 `setAutoHeight` 设置的行高；尚未测量的行使用 `autoRowHeight.expectedHeight`，再回退到 `rowHeight`。
+:::
 
 ### getTableData
 获取表格数据，返回当前表格的排序顺序的数组
@@ -298,4 +345,3 @@ function copySelectedArea(): string
  */
 function setFilter(status: Record<UniqKey, FilterStatus> | null, option?: { remote?: boolean; silent?: boolean })
 ```
-

--- a/docs-src/main/api/expose.md
+++ b/docs-src/main/api/expose.md
@@ -174,30 +174,65 @@ function setSorter(
 按坐标、行索引、行 key 或边界滚动表格。接口形式与原生 `Element.scrollTo` / Naive UI Virtual List 一致。
 
 ```ts
+interface CommonScrollToOptions {
+    behavior?: ScrollBehavior
+    debounce?: boolean
+}
+
+type ScrollToOptions = CommonScrollToOptions & (
+    | {
+          left: number
+          top?: number
+          index?: never
+          key?: never
+          position?: never
+      }
+    | {
+          left?: number
+          top: number
+          index?: never
+          key?: never
+          position?: never
+      }
+    | {
+          left?: never
+          top?: never
+          index: number
+          key?: never
+          position?: never
+      }
+    | {
+          left?: never
+          top?: never
+          index?: never
+          key: string | number
+          position?: never
+      }
+    | {
+          left?: never
+          top?: never
+          index?: never
+          key?: never
+          position: 'top' | 'bottom'
+      }
+)
+
 interface ScrollTo {
     (x: number, y: number): void
-    (options: {
-        left?: number
-        top?: number
-        behavior?: ScrollBehavior
-        debounce?: boolean
-    }): void
-    (options: {
-        index: number
-        behavior?: ScrollBehavior
-        debounce?: boolean
-    }): void
-    (options: {
-        key: string | number
-        behavior?: ScrollBehavior
-        debounce?: boolean
-    }): void
-    (options: {
-        position: 'top' | 'bottom'
-        behavior?: ScrollBehavior
-        debounce?: boolean
-    }): void
+    (options: ScrollToOptions): void
 }
+```
+
+`ScrollTo`、`ScrollToOptions` 和 `CommonScrollToOptions` 都是从包根入口导出的公共类型。`ScrollToOptions` 是互斥 union：坐标形式至少需要 `left` 或 `top`，其他形式只能包含 `index`、`key`、`position` 中的一个；空对象或混合目标会在 TypeScript 编译期报错。
+
+```ts
+import type { CommonScrollToOptions, ScrollTo, ScrollToOptions } from 'stk-table-vue'
+
+const common: CommonScrollToOptions = { behavior: 'smooth', debounce: false }
+const target: ScrollToOptions = { key: orderId, ...common }
+const scroll: ScrollTo = tableRef.value!.scrollTo
+
+scroll(target)
 ```
 
 - `(x, y)` 中 `x` 表示横向 `left`，`y` 表示纵向 `top`。

--- a/docs-src/main/table/advanced/virtual.md
+++ b/docs-src/main/table/advanced/virtual.md
@@ -64,6 +64,17 @@ initVirtualScroll(height?: number)
 <StkTable :autoResize="false"></StkTable>
 ```
 
+## 定位滚动
+
+实例方法 `scrollTo` 支持按坐标、当前展示行的 `index` / `rowKey`，以及表格顶部或底部定位，并可配置平滑滚动。
+
+```ts
+tableRef.value?.scrollTo({ index: 100 })
+tableRef.value?.scrollTo({ key: orderId, behavior: 'smooth' })
+tableRef.value?.scrollTo({ position: 'bottom' })
+```
+
+完整签名、`debounce` 语义和数值重载迁移说明请参见 [`scrollTo` 实例方法](/main/api/expose#scrollto)。
+
 ## 单列表
 请移步至[虚拟单列表](/demos/virtual-list.html)
-

--- a/openspec/specs/virtual-scroll/spec.md
+++ b/openspec/specs/virtual-scroll/spec.md
@@ -45,3 +45,22 @@
 
 - **WHEN** 用户手动拖动改变表格宽高后，调用 `initVirtualScroll`
 - **THEN** 可视区按新的容器尺寸重新计算并正确渲染
+
+### Requirement: 提供与 Naive UI Virtual List 对齐的 scrollTo 实例方法
+
+组件 SHALL expose `scrollTo`，并支持 `(x, y)` 数值坐标、`{ left?, top? }` 坐标对象、`{ index }`、`{ key }` 与 `{ position: 'top' | 'bottom' }` 五种调用形式；对象形式 SHALL 支持原生 `ScrollBehavior`。`index` 与 `key` 形式的 `debounce` 默认为 `true`，目标行完全可见时 MUST 保持当前滚动位置，否则 MUST 以最小距离使目标行可见；`debounce: false` 时 MUST 将目标行对齐到表体顶部。索引与 key MUST 基于排序、筛选及树形展开后的当前展示数据。
+
+#### Scenario: 通过行 key 定位当前展示行
+
+- **WHEN** 调用 `scrollTo({ key, behavior: 'smooth' })` 且该 key 对应当前展示数据中的一行
+- **THEN** 表格以平滑滚动方式用最小距离使该行完全可见
+
+#### Scenario: 强制将指定索引行对齐到顶部
+
+- **WHEN** 调用 `scrollTo({ index: 100, debounce: false })`
+- **THEN** 当前展示顺序中的第 101 行与表体顶部对齐
+
+#### Scenario: key 或 index 无效
+
+- **WHEN** `key` 未匹配当前展示数据，或 `index` 越界
+- **THEN** 当前滚动位置保持不变且不抛出异常

--- a/openspec/specs/virtual-scroll/spec.md
+++ b/openspec/specs/virtual-scroll/spec.md
@@ -48,7 +48,7 @@
 
 ### Requirement: 提供与 Naive UI Virtual List 对齐的 scrollTo 实例方法
 
-组件 SHALL expose `scrollTo`，并支持 `(x, y)` 数值坐标、`{ left?, top? }` 坐标对象、`{ index }`、`{ key }` 与 `{ position: 'top' | 'bottom' }` 五种调用形式；对象形式 SHALL 支持原生 `ScrollBehavior`。`index` 与 `key` 形式的 `debounce` 默认为 `true`，目标行完全可见时 MUST 保持当前滚动位置，否则 MUST 以最小距离使目标行可见；`debounce: false` 时 MUST 将目标行对齐到表体顶部。索引与 key MUST 基于排序、筛选及树形展开后的当前展示数据。
+组件 SHALL expose `scrollTo`，并支持 `(x, y)` 数值坐标、`{ left?, top? }` 坐标对象、`{ index }`、`{ key }` 与 `{ position: 'top' | 'bottom' }` 五种调用形式；对象形式 SHALL 支持原生 `ScrollBehavior`。包根入口 SHALL 导出 `ScrollTo`、`ScrollToOptions` 与 `CommonScrollToOptions` 公共类型，其中 `ScrollToOptions` MUST 以互斥 union 拒绝空目标和混合目标。`index` 与 `key` 形式的 `debounce` 默认为 `true`，目标行完全可见时 MUST 保持当前滚动位置，否则 MUST 以最小距离使目标行可见；`debounce: false` 时 MUST 将目标行对齐到表体顶部。索引与 key MUST 基于排序、筛选及树形展开后的当前展示数据。
 
 #### Scenario: 通过行 key 定位当前展示行
 
@@ -64,3 +64,8 @@
 
 - **WHEN** `key` 未匹配当前展示数据，或 `index` 越界
 - **THEN** 当前滚动位置保持不变且不抛出异常
+
+#### Scenario: 实验滚动使用统一的纵向几何模型
+
+- **WHEN** 实验性纵向滚动启用，且存在已测量的可变行高或粘性 footer
+- **THEN** `scrollTo` 目标计算、纵向位置截断与自定义滚动条 MUST 使用同一份总行高、footer 高度和最大滚动位置，顶部/底部及索引目标均可到达

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dev": "vite",
     "build": "vite build",
     "test": "vitest",
+    "test:types": "tsc -p tsconfig.type-tests.json",
     "docs:dev": "vitepress dev docs-src",
     "docs:build": "vitepress build docs-src",
     "docs:preview": "vitepress preview docs-src",

--- a/src/StkTable/StkTable.vue
+++ b/src/StkTable/StkTable.vue
@@ -304,7 +304,7 @@ export default {
 /**
  * @author japlus
  */
-import { computed, nextTick, onMounted, provide, ref, shallowRef, toRaw, toRef, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, provide, ref, shallowRef, toRaw, toRef, watch } from 'vue';
 import DragHandle from './components/DragHandle.vue';
 import SortIcon from './components/SortIcon.vue';
 import TreeNodeCell from './components/TreeNodeCell.vue';
@@ -335,6 +335,8 @@ import {
     PrivateRowDT,
     PrivateStkTableColumn,
     RowActiveOption,
+    ScrollTo,
+    ScrollToOptions,
     SeqConfig,
     SortConfig,
     StkTableColumn,
@@ -918,6 +920,7 @@ const [
     theadVirtualX,
     virtualX_columnPart,
     virtualX_expandColSegments,
+    getRowHeightFn,
 ] = useVirtualScroll(
     props,
     tableContainerRef,
@@ -1042,7 +1045,7 @@ const {
     tableHeaderLast,
     colKeyGen,
     cellKeyGen,
-    scrollTo,
+    setScrollPosition,
     virtualScroll,
     virtualScrollX,
     getRowIndex,
@@ -1050,7 +1053,7 @@ const {
 );
 
 /** 键盘箭头滚动 */
-useKeyboardArrowScroll(tableContainerRef, props, scrollTo, virtualScroll, virtualScrollX, tableHeaders, virtual_on, areaSelectionConfig);
+useKeyboardArrowScroll(tableContainerRef, props, setScrollPosition, virtualScroll, virtualScrollX, tableHeaders, virtual_on, areaSelectionConfig);
 
 /** 固定列处理 */
 const [fixedCols, fixedColClassMap, updateFixedShadow] = useFixedCol(
@@ -1922,23 +1925,145 @@ function setSelectedCell(row?: DT, col?: StkTableColumn<DT>, option = { silent: 
     }
 }
 
-/**
- * set scroll bar position
- * @param top null to not change
- * @param left null to not change
- */
-function scrollTo(top: number | null = 0, left: number | null = 0) {
-    if (!tableContainerRef.value) return;
-    if (top !== null) {
-        if (isExperimentalScrollY.value) {
-            updateVirtualScrollY(top);
-            updateCustomScrollbar();
-        } else {
-            tableContainerRef.value.scrollTop = top;
-        }
-    }
-    if (left !== null) tableContainerRef.value.scrollLeft = left;
+let smoothScrollFrame: number | null = null;
+
+function cancelSmoothScroll() {
+    if (smoothScrollFrame === null) return;
+    cancelAnimationFrame(smoothScrollFrame);
+    smoothScrollFrame = null;
 }
+
+onBeforeUnmount(cancelSmoothScroll);
+
+function getRowsHeight(endIndex = dataSourceCopy.value.length) {
+    let height = 0;
+    const rows = dataSourceCopy.value;
+    const getRowHeight = getRowHeightFn.value;
+    for (let i = 0; i < endIndex; i++) {
+        height += getRowHeight(rows[i]);
+    }
+    return height;
+}
+
+function getBodyViewportHeight() {
+    const container = tableContainerRef.value;
+    if (!container) return 0;
+    const footer = container.querySelector<HTMLElement>('.stk-footer');
+    const footerHeight = footer?.offsetHeight || 0;
+    const containerHeight = virtualScroll.value.containerHeight || container.clientHeight;
+    const headerHeight = props.headless ? 0 : tableHeaderHeight.value;
+    return Math.max(0, containerHeight - headerHeight - footerHeight);
+}
+
+function getMaxScrollTop() {
+    const container = tableContainerRef.value;
+    if (!container) return 0;
+    const nativeMax = Math.max(0, container.scrollHeight - container.clientHeight);
+    const estimatedMax = Math.max(0, getRowsHeight() - getBodyViewportHeight());
+    return Math.max(nativeMax, estimatedMax);
+}
+
+function scrollExperimentalY(top: number, behavior?: ScrollBehavior) {
+    const targetTop = Math.min(Math.max(0, top), getMaxScrollTop());
+    cancelSmoothScroll();
+    if (behavior !== 'smooth') {
+        updateVirtualScrollY(targetTop);
+        updateCustomScrollbar();
+        return;
+    }
+
+    const startTop = virtualScroll.value.scrollTop;
+    const distance = targetTop - startTop;
+    if (!distance) return;
+    const duration = 300;
+    let startTime: number | null = null;
+    const step = (timestamp: number) => {
+        startTime ??= timestamp;
+        const progress = Math.min(1, (timestamp - startTime) / duration);
+        const easedProgress = 1 - (1 - progress) ** 3;
+        updateVirtualScrollY(startTop + distance * easedProgress);
+        updateCustomScrollbar();
+        if (progress < 1) {
+            smoothScrollFrame = requestAnimationFrame(step);
+        } else {
+            smoothScrollFrame = null;
+        }
+    };
+    smoothScrollFrame = requestAnimationFrame(step);
+}
+
+/** Internal helper. Arguments keep the historical top/left order for keyboard and area-selection features. */
+function setScrollPosition(top: number | null | undefined, left: number | null | undefined, behavior?: ScrollBehavior) {
+    const container = tableContainerRef.value;
+    if (!container) return;
+
+    if (top !== null && top !== undefined && isExperimentalScrollY.value) {
+        scrollExperimentalY(top, behavior);
+    } else {
+        cancelSmoothScroll();
+    }
+
+    const nativeOptions: { left?: number; top?: number; behavior?: ScrollBehavior } = {};
+    if (top !== null && top !== undefined && !isExperimentalScrollY.value) nativeOptions.top = top;
+    if (left !== null && left !== undefined) nativeOptions.left = left;
+    if (behavior !== undefined) nativeOptions.behavior = behavior;
+    if (nativeOptions.top === undefined && nativeOptions.left === undefined) return;
+
+    if (behavior === 'smooth' && typeof container.scrollTo === 'function') {
+        container.scrollTo(nativeOptions);
+    } else {
+        if (nativeOptions.top !== undefined) container.scrollTop = nativeOptions.top;
+        if (nativeOptions.left !== undefined) container.scrollLeft = nativeOptions.left;
+    }
+}
+
+function scrollToIndex(index: number, behavior?: ScrollBehavior, debounce = true) {
+    const rows = dataSourceCopy.value;
+    if (!Number.isInteger(index) || index < 0 || index >= rows.length) return;
+
+    const targetTop = getRowsHeight(index);
+    const targetBottom = targetTop + getRowHeightFn.value(rows[index]);
+    if (!debounce) {
+        setScrollPosition(targetTop, 0, behavior);
+        return;
+    }
+
+    const container = tableContainerRef.value;
+    if (!container) return;
+    const visibleTop = isExperimentalScrollY.value ? virtualScroll.value.scrollTop : container.scrollTop;
+    const bodyViewportHeight = getBodyViewportHeight();
+    const visibleBottom = visibleTop + bodyViewportHeight;
+    if (targetTop < visibleTop) {
+        setScrollPosition(targetTop, 0, behavior);
+    } else if (targetBottom > visibleBottom) {
+        setScrollPosition(targetBottom - bodyViewportHeight, 0, behavior);
+    }
+}
+
+/**
+ * Scroll the table to coordinates, a row, or a boundary.
+ * The numeric overload follows the native x/y (left/top) order.
+ */
+const scrollTo: ScrollTo = (options: ScrollToOptions | number, y?: number): void => {
+    if (typeof options === 'number') {
+        setScrollPosition(y ?? 0, options);
+        return;
+    }
+
+    const { left, top, index, key, position, behavior, debounce = true } = options;
+    if (left !== undefined || top !== undefined) {
+        setScrollPosition(top, left, behavior);
+    } else if (index !== undefined) {
+        scrollToIndex(index, behavior, debounce);
+    } else if (key !== undefined) {
+        const targetIndex = dataSourceCopy.value.findIndex(row => rowKeyGen(row) === key);
+        if (targetIndex !== -1) scrollToIndex(targetIndex, behavior, debounce);
+    } else if (position === 'bottom') {
+        setScrollPosition(getMaxScrollTop(), 0, behavior);
+    } else if (position === 'top') {
+        setScrollPosition(0, 0, behavior);
+    }
+};
 
 /** get current table data */
 function getTableData() {

--- a/src/StkTable/StkTable.vue
+++ b/src/StkTable/StkTable.vue
@@ -768,6 +768,14 @@ const isFooterTop = computed(() => props.footerConfig?.position === 'top');
 /** 表格底部标签名：顶部吸附用 tbody，底部吸附用 tfoot */
 const footerTagName = computed(() => (isFooterTop.value ? 'tbody' : 'tfoot'));
 
+function getFooterHeight() {
+    if (!props.footerData.length) return 0;
+    const footer = tableContainerRef.value?.querySelector<HTMLElement>('.stk-footer');
+    if (footer?.offsetHeight) return footer.offsetHeight;
+    const fallbackRowHeight = Number.parseFloat(String(props.footerRowHeight)) || props.rowHeight || DEFAULT_ROW_HEIGHT;
+    return props.footerData.length * fallbackRowHeight;
+}
+
 /**
  * 当前选中的一行
  * - shallowRef： 使 currentRow.value === row 地址相同。防止rowKeyGen 的WeakMap key不一致。
@@ -920,7 +928,10 @@ const [
     theadVirtualX,
     virtualX_columnPart,
     virtualX_expandColSegments,
-    getRowHeightFn,
+    getRowsHeight,
+    getRowHeight,
+    getBodyViewportHeight,
+    getVerticalScrollMetrics,
 ] = useVirtualScroll(
     props,
     tableContainerRef,
@@ -931,8 +942,8 @@ const [
     rowKeyGen,
     maxRowSpan,
     getMaxRowSpanValue,
-    scrollbarOptions,
     isExperimentalScrollY,
+    getFooterHeight,
     mergeCellsCache,
 );
 
@@ -1757,9 +1768,9 @@ function onTableWheel(e: WheelEvent) {
     const { deltaY, deltaX, shiftKey } = e;
 
     if (virtual_on.value && deltaY && !shiftKey) {
-        const { containerHeight, scrollTop, scrollHeight } = virtualScroll.value;
+        const { scrollTop, maxScrollTop } = virtualScroll.value;
         // overflow: hidden mode: manually control scroll, preventDefault to block parent scroll
-        const canScrollDown = scrollTop < scrollHeight - containerHeight - 1;
+        const canScrollDown = scrollTop < maxScrollTop - 1;
         const canScrollUp = scrollTop > 1;
 
         if ((deltaY > 0 && canScrollDown) || (deltaY < 0 && canScrollUp)) {
@@ -1935,36 +1946,8 @@ function cancelSmoothScroll() {
 
 onBeforeUnmount(cancelSmoothScroll);
 
-function getRowsHeight(endIndex = dataSourceCopy.value.length) {
-    let height = 0;
-    const rows = dataSourceCopy.value;
-    const getRowHeight = getRowHeightFn.value;
-    for (let i = 0; i < endIndex; i++) {
-        height += getRowHeight(rows[i]);
-    }
-    return height;
-}
-
-function getBodyViewportHeight() {
-    const container = tableContainerRef.value;
-    if (!container) return 0;
-    const footer = container.querySelector<HTMLElement>('.stk-footer');
-    const footerHeight = footer?.offsetHeight || 0;
-    const containerHeight = virtualScroll.value.containerHeight || container.clientHeight;
-    const headerHeight = props.headless ? 0 : tableHeaderHeight.value;
-    return Math.max(0, containerHeight - headerHeight - footerHeight);
-}
-
-function getMaxScrollTop() {
-    const container = tableContainerRef.value;
-    if (!container) return 0;
-    const nativeMax = Math.max(0, container.scrollHeight - container.clientHeight);
-    const estimatedMax = Math.max(0, getRowsHeight() - getBodyViewportHeight());
-    return Math.max(nativeMax, estimatedMax);
-}
-
 function scrollExperimentalY(top: number, behavior?: ScrollBehavior) {
-    const targetTop = Math.min(Math.max(0, top), getMaxScrollTop());
+    const targetTop = Math.min(Math.max(0, top), getVerticalScrollMetrics().maxScrollTop);
     cancelSmoothScroll();
     if (behavior !== 'smooth') {
         updateVirtualScrollY(targetTop);
@@ -2022,7 +2005,7 @@ function scrollToIndex(index: number, behavior?: ScrollBehavior, debounce = true
     if (!Number.isInteger(index) || index < 0 || index >= rows.length) return;
 
     const targetTop = getRowsHeight(index);
-    const targetBottom = targetTop + getRowHeightFn.value(rows[index]);
+    const targetBottom = targetTop + getRowHeight(rows[index]);
     if (!debounce) {
         setScrollPosition(targetTop, 0, behavior);
         return;
@@ -2051,7 +2034,11 @@ const scrollTo: ScrollTo = (options: ScrollToOptions | number, y?: number): void
     }
 
     const { left, top, index, key, position, behavior, debounce = true } = options;
-    if (left !== undefined || top !== undefined) {
+    const hasCoordinates = left !== undefined || top !== undefined;
+    const targetCount = Number(hasCoordinates) + Number(index !== undefined) + Number(key !== undefined) + Number(position !== undefined);
+    if (targetCount !== 1) return;
+
+    if (hasCoordinates) {
         setScrollPosition(top, left, behavior);
     } else if (index !== undefined) {
         scrollToIndex(index, behavior, debounce);
@@ -2059,7 +2046,7 @@ const scrollTo: ScrollTo = (options: ScrollToOptions | number, y?: number): void
         const targetIndex = dataSourceCopy.value.findIndex(row => rowKeyGen(row) === key);
         if (targetIndex !== -1) scrollToIndex(targetIndex, behavior, debounce);
     } else if (position === 'bottom') {
-        setScrollPosition(getMaxScrollTop(), 0, behavior);
+        setScrollPosition(getVerticalScrollMetrics().maxScrollTop, 0, behavior);
     } else if (position === 'top') {
         setScrollPosition(0, 0, behavior);
     }

--- a/src/StkTable/index.ts
+++ b/src/StkTable/index.ts
@@ -1,7 +1,17 @@
 export { useAreaSelection } from './features/index';
 export { registerFeature } from './registerFeature';
 export { default as StkTable } from './StkTable.vue';
-export type { AreaSelectionRange, Order, SortConfig, SortOption, SortState, StkTableColumn } from './types/index';
+export type {
+    AreaSelectionRange,
+    CommonScrollToOptions,
+    Order,
+    ScrollTo,
+    ScrollToOptions,
+    SortConfig,
+    SortOption,
+    SortState,
+    StkTableColumn,
+} from './types/index';
 export { binarySearch, insertToOrderedArray, strCompare, tableSort } from './utils';
 // export custom cells
 export { createFilterCell } from './custom-cells/FilterCell/index';

--- a/src/StkTable/types/index.ts
+++ b/src/StkTable/types/index.ts
@@ -238,21 +238,54 @@ export interface CommonScrollToOptions {
     debounce?: boolean;
 }
 
-export interface ScrollToOptions extends CommonScrollToOptions {
-    left?: number;
-    top?: number;
-    index?: number;
-    key?: UniqKey;
-    position?: 'top' | 'bottom';
-}
+type ScrollToCoordinateOptions =
+    | {
+          left: number;
+          top?: number;
+          index?: never;
+          key?: never;
+          position?: never;
+      }
+    | {
+          left?: number;
+          top: number;
+          index?: never;
+          key?: never;
+          position?: never;
+      };
+
+type ScrollToIndexOptions = {
+    left?: never;
+    top?: never;
+    index: number;
+    key?: never;
+    position?: never;
+};
+
+type ScrollToKeyOptions = {
+    left?: never;
+    top?: never;
+    index?: never;
+    key: UniqKey;
+    position?: never;
+};
+
+type ScrollToPositionOptions = {
+    left?: never;
+    top?: never;
+    index?: never;
+    key?: never;
+    position: 'top' | 'bottom';
+};
+
+/** Mutually exclusive target options accepted by {@link ScrollTo}. */
+export type ScrollToOptions = CommonScrollToOptions &
+    (ScrollToCoordinateOptions | ScrollToIndexOptions | ScrollToKeyOptions | ScrollToPositionOptions);
 
 /** Scroll the table to coordinates, a row, or a boundary. */
 export interface ScrollTo {
     (x: number, y: number): void;
-    (options: { left?: number; top?: number } & CommonScrollToOptions): void;
-    (options: { index: number } & CommonScrollToOptions): void;
-    (options: { key: UniqKey } & CommonScrollToOptions): void;
-    (options: { position: 'top' | 'bottom' } & CommonScrollToOptions): void;
+    (options: ScrollToOptions): void;
 }
 
 /**

--- a/src/StkTable/types/index.ts
+++ b/src/StkTable/types/index.ts
@@ -227,6 +227,34 @@ export type UniqKey = string | number;
 export type UniqKeyFun = (param: any) => UniqKey;
 export type UniqKeyProp = UniqKey | UniqKeyFun;
 
+export interface CommonScrollToOptions {
+    /** Native scroll behavior. */
+    behavior?: ScrollBehavior;
+    /**
+     * When scrolling by index or key, only scroll when the target row is outside the viewport.
+     * Set to false to always align the target row with the top of the table body.
+     * @default true
+     */
+    debounce?: boolean;
+}
+
+export interface ScrollToOptions extends CommonScrollToOptions {
+    left?: number;
+    top?: number;
+    index?: number;
+    key?: UniqKey;
+    position?: 'top' | 'bottom';
+}
+
+/** Scroll the table to coordinates, a row, or a boundary. */
+export interface ScrollTo {
+    (x: number, y: number): void;
+    (options: { left?: number; top?: number } & CommonScrollToOptions): void;
+    (options: { index: number } & CommonScrollToOptions): void;
+    (options: { key: UniqKey } & CommonScrollToOptions): void;
+    (options: { position: 'top' | 'bottom' } & CommonScrollToOptions): void;
+}
+
 /**
  * 默认排序配置
  */

--- a/src/StkTable/useKeyboardArrowScroll.ts
+++ b/src/StkTable/useKeyboardArrowScroll.ts
@@ -71,7 +71,7 @@ export function useKeyboardArrowScroll<DT extends Record<string, any>>(
         if (!isMouseOver) return; // 不悬浮还是要触发键盘事件的
         e.preventDefault(); // 不触发键盘默认的箭头事件
 
-        const { scrollTop, rowHeight, containerHeight, scrollHeight } = virtualScroll.value;
+        const { scrollTop, rowHeight, containerHeight, maxScrollTop } = virtualScroll.value;
         const { scrollLeft } = virtualScrollX.value;
         const { headless, headerRowHeight } = props;
 
@@ -94,7 +94,7 @@ export function useKeyboardArrowScroll<DT extends Record<string, any>>(
         } else if (keyCode === ScrollCodes.Home) {
             scrollTo(0, null);
         } else if (keyCode === ScrollCodes.End) {
-            scrollTo(scrollHeight, null);
+            scrollTo(maxScrollTop, null);
         }
     }
 

--- a/src/StkTable/useScrollbar.ts
+++ b/src/StkTable/useScrollbar.ts
@@ -71,17 +71,18 @@ export function useScrollbar(
 
     function updateCustomScrollbar() {
         if (!scrollbarOptions.value.enabled || isMobileDevice) return;
-        const { scrollHeight, scrollTop, containerHeight } = virtualScroll.value;
+        const { scrollHeight, scrollTop, maxScrollTop, containerHeight } = virtualScroll.value;
         const { scrollWidth, scrollLeft, containerWidth } = virtualScrollX.value;
 
-        const needVertical = scrollHeight > containerHeight;
+        const needVertical = maxScrollTop > 0;
         const needHorizontal = scrollWidth > containerWidth;
         showScrollbar.value = { x: needHorizontal, y: needVertical };
 
         if (needVertical) {
             const ratio = containerHeight / scrollHeight;
             scrollbar.value.h = Math.max(scrollbarOptions.value.minHeight, ratio * containerHeight);
-            scrollbar.value.t = Math.round((scrollTop / (scrollHeight - containerHeight)) * (containerHeight - scrollbar.value.h));
+            const scrollRatio = Math.min(Math.max(0, scrollTop), maxScrollTop) / maxScrollTop;
+            scrollbar.value.t = Math.round(scrollRatio * (containerHeight - scrollbar.value.h));
         }
 
         if (needHorizontal) {
@@ -123,17 +124,15 @@ export function useScrollbar(
         e.preventDefault();
         const clientY = e instanceof MouseEvent ? e.clientY : e.touches[0].clientY;
         const deltaY = clientY - dragStartY;
-        const { scrollHeight, containerHeight } = virtualScroll.value;
-        const scrollRange = scrollHeight - containerHeight;
+        const { maxScrollTop: scrollRange, containerHeight } = virtualScroll.value;
         const trackRange = containerHeight - scrollbar.value.h;
+        if (scrollRange <= 0 || trackRange <= 0) return;
         const scrollDelta = (deltaY / trackRange) * scrollRange;
 
         if (isExperimentalScrollY.value) {
-            const ratio = containerHeight / scrollHeight;
-            const top = Math.round((dragStartTop + scrollDelta) * ratio);
-            const maxTop = containerHeight - scrollbar.value.h;
-            scrollbar.value.t = top < 0 ? 0 : top > maxTop ? maxTop : top;
-            rafUpdateVirtualScrollY(dragStartTop + scrollDelta);
+            const targetTop = Math.min(Math.max(0, dragStartTop + scrollDelta), scrollRange);
+            scrollbar.value.t = Math.round((targetTop / scrollRange) * trackRange);
+            rafUpdateVirtualScrollY(targetTop);
         } else {
             containerRef.value!.scrollTop = dragStartTop + scrollDelta;
         }

--- a/src/StkTable/useVirtualScroll.ts
+++ b/src/StkTable/useVirtualScroll.ts
@@ -897,5 +897,6 @@ export function useVirtualScroll(
         theadVirtualX,
         virtualX_columnPart,
         virtualX_expandColSegments,
+        getRowHeightFn,
     ] as const;
 }

--- a/src/StkTable/useVirtualScroll.ts
+++ b/src/StkTable/useVirtualScroll.ts
@@ -1,8 +1,7 @@
-import { Ref, ShallowRef, computed, ref, shallowRef, triggerRef } from 'vue';
+import { Ref, ShallowRef, computed, shallowRef, triggerRef } from 'vue';
 import { DEFAULT_ROW_HEIGHT, DEFAULT_TABLE_HEIGHT, DEFAULT_TABLE_WIDTH } from './const';
 import { MergeCellsCache } from './mergeCellsCache';
 import { AutoRowHeightConfig, PrivateRowDT, PrivateStkTableColumn, RowKeyGen, StkTableColumn, UniqKey } from './types';
-import { ScrollbarOptions } from './useScrollbar';
 import { binarySearch } from './utils';
 import { getCalculatedColWidth } from './utils/constRefUtils';
 
@@ -24,11 +23,23 @@ export type VirtualScrollStore = {
     scrollTop: number;
     /** 总滚动高度 */
     scrollHeight: number;
+    /** 纵向最大滚动位置 */
+    maxScrollTop: number;
     translateY: number;
     /** 视口实际起始行索引（rowspan 修正前的原始值，用于区分 above-viewport 行） */
     viewportStartIndex: number;
     /** 视口实际结束行索引（rowspan 修正前的原始值，用于区分 below-viewport 行） */
     viewportEndIndex: number;
+};
+
+export type VerticalScrollMetrics = {
+    rowsHeight: number;
+    headerHeight: number;
+    footerHeight: number;
+    containerHeight: number;
+    bodyViewportHeight: number;
+    scrollHeight: number;
+    maxScrollTop: number;
 };
 /** 暂存横向虚拟滚动的数据 */
 export type VirtualScrollXStore = {
@@ -112,8 +123,8 @@ export function useVirtualScroll(
     maxRowSpan: Map<UniqKey, number>,
     /** 全局最大 rowspan（限定跨界修正扫描范围用） */
     getMaxRowSpanValue: () => number,
-    scrollbarOptions: Ref<Required<ScrollbarOptions>>,
     isExperimentalScrollY: Ref<boolean | undefined>,
+    getFooterHeight: () => number,
     /** mergeCells 结果共享缓存（与 useMergeCells 共用，避免重复调用用户回调） */
     mergeCellsCache: MergeCellsCache,
 ) {
@@ -128,6 +139,7 @@ export function useVirtualScroll(
         offsetTop: 0,
         scrollTop: 0,
         scrollHeight: 0,
+        maxScrollTop: 0,
         translateY: 0,
         viewportStartIndex: 0,
         viewportEndIndex: 0,
@@ -525,6 +537,50 @@ export function useVirtualScroll(
         return rowHeightFn;
     });
 
+    function getRowHeight(row?: PrivateRowDT) {
+        return getRowHeightFn.value(row);
+    }
+
+    function getRowsHeight(endIndex = dataSourceCopy.value.length) {
+        const rows = dataSourceCopy.value;
+        const rowCount = Math.min(endIndex, rows.length);
+        if (!props.autoRowHeight && !hasExpandCol.value) {
+            return rowCount * getRowHeightFn.value();
+        }
+
+        let height = 0;
+        const getRowHeight = getRowHeightFn.value;
+        for (let i = 0; i < rowCount; i++) {
+            height += getRowHeight(rows[i]);
+        }
+        return height;
+    }
+
+    function getBodyViewportHeight() {
+        const containerHeight = virtualScroll.value.containerHeight || tableContainerRef.value?.clientHeight || DEFAULT_TABLE_HEIGHT;
+        const headerHeight = props.headless ? 0 : tableHeaderHeight.value;
+        return Math.max(0, containerHeight - headerHeight - getFooterHeight());
+    }
+
+    function getVerticalScrollMetrics(): VerticalScrollMetrics {
+        const containerHeight = virtualScroll.value.containerHeight || tableContainerRef.value?.clientHeight || DEFAULT_TABLE_HEIGHT;
+        const headerHeight = props.headless ? 0 : tableHeaderHeight.value;
+        const footerHeight = getFooterHeight();
+        const rowsHeight = getRowsHeight();
+        const modeledScrollHeight = rowsHeight + headerHeight + footerHeight;
+        const nativeScrollHeight = tableContainerRef.value?.scrollHeight || 0;
+        const scrollHeight = Math.max(modeledScrollHeight, nativeScrollHeight);
+        return {
+            rowsHeight,
+            headerHeight,
+            footerHeight,
+            containerHeight,
+            bodyViewportHeight: Math.max(0, containerHeight - headerHeight - footerHeight),
+            scrollHeight,
+            maxScrollTop: Math.max(0, scrollHeight - containerHeight),
+        };
+    }
+
     /**
      * 初始化虚拟滚动参数
      * @param {number} [height] 虚拟滚动的高度
@@ -543,7 +599,7 @@ export function useVirtualScroll(
             console.warn('initVirtualScrollY: height must be a number');
             height = 0;
         }
-        const { clientHeight, scrollHeight } = tableContainerRef.value || {};
+        const { clientHeight } = tableContainerRef.value || {};
         // 当 isExperimentalScrollY 为 true 时，DOM 的 scrollTop 始终为 0（纵向滚动通过 transform 模拟）
         // 此时应该使用 virtualScroll 中保存的 scrollTop 值
         let scrollTop = isExperimentalScrollY.value ? virtualScroll.value.scrollTop : tableContainerRef.value?.scrollTop || 0;
@@ -557,12 +613,13 @@ export function useVirtualScroll(
             const headerToBodyRowHeightCount = Math.floor(tableHeaderHeight.value / rowHeight);
             pageSize -= headerToBodyRowHeightCount; //减去表头行数
         }
-        const maxScrollTop = Math.max(0, dataSourceCopy.value.length * rowHeight + tableHeaderHeight.value - containerHeight);
+        Object.assign(virtualScroll.value, { containerHeight, pageSize });
+        const { scrollHeight, maxScrollTop } = getVerticalScrollMetrics();
         if (scrollTop > maxScrollTop) {
             /** fix： 滚动条不在顶部时，表格数据变少，导致滚动条位置有误 */
             scrollTop = maxScrollTop;
         }
-        Object.assign(virtualScroll.value, { containerHeight, pageSize, scrollHeight });
+        Object.assign(virtualScroll.value, { scrollHeight, maxScrollTop });
         triggerRef(virtualScroll);
         updateVirtualScrollY(scrollTop);
     }
@@ -622,16 +679,24 @@ export function useVirtualScroll(
         const dataLength = dataSourceCopyTemp.length;
         const rowHeight = getRowHeightFn.value();
 
-        const vsValue: any = {};
-        const scrollHeight = dataLength * rowHeight + tableHeaderHeight.value;
-        const { enabled: scrollbarEnable } = scrollbarOptions.value;
-        if (scrollbarEnable) {
-            vsValue.scrollHeight = scrollHeight;
-            if (isExperimentalScrollY.value) {
-                let maxTop: number;
-                sTop = sTop < 0 ? 0 : sTop < (maxTop = scrollHeight - containerHeight) ? sTop : maxTop;
-                vsValue.translateY = props.scrollRowByRow ? 0 : -(sTop % rowHeight);
+        if (props.autoRowHeight && trRef.value) {
+            // Measure before deriving total height so clamping and scrollbar metrics use the latest known heights.
+            const trElements = trRef.value;
+            for (let i = 0, len = trElements.length; i < len; i++) {
+                const tr = trElements[i];
+                const rowKey = tr.dataset.rowKey;
+                if (!rowKey || autoRowHeightMap.has(rowKey)) continue;
+                autoRowHeightMap.set(rowKey, tr.offsetHeight);
             }
+        }
+
+        const vsValue: any = {};
+        const { scrollHeight, maxScrollTop } = getVerticalScrollMetrics();
+        vsValue.scrollHeight = scrollHeight;
+        vsValue.maxScrollTop = maxScrollTop;
+        if (isExperimentalScrollY.value) {
+            sTop = Math.min(Math.max(0, sTop), maxScrollTop);
+            vsValue.translateY = props.scrollRowByRow ? 0 : -(sTop % rowHeight);
         }
         vsValue.scrollTop = sTop;
 
@@ -658,16 +723,6 @@ export function useVirtualScroll(
         let endIndex = dataLength;
         let autoRowHeightTop = 0;
         if (autoRowHeight || hasExpandCol.value) {
-            if (autoRowHeight && trRef.value) {
-                // Batch DOM measurements for better performance
-                const trElements = trRef.value;
-                for (let i = 0, len = trElements.length; i < len; i++) {
-                    const tr = trElements[i];
-                    const rowKey = tr.dataset.rowKey;
-                    if (!rowKey || autoRowHeightMap.has(rowKey)) continue;
-                    autoRowHeightMap.set(rowKey, tr.offsetHeight);
-                }
-            }
             // calculate startIndex
             for (let i = 0; i < dataLength; i++) {
                 const height = getRowHeightFn.value(dataSourceCopyTemp[i]);
@@ -897,6 +952,9 @@ export function useVirtualScroll(
         theadVirtualX,
         virtualX_columnPart,
         virtualX_expandColSegments,
-        getRowHeightFn,
+        getRowsHeight,
+        getRowHeight,
+        getBodyViewportHeight,
+        getVerticalScrollMetrics,
     ] as const;
 }

--- a/test/scrollTo.test.js
+++ b/test/scrollTo.test.js
@@ -28,6 +28,11 @@ function createWrapper(extraProps = {}) {
     return wrapper;
 }
 
+function getSetupState(wrapper, key) {
+    const state = wrapper.vm.$.setupState[key];
+    return state?.value ?? state;
+}
+
 describe('scrollTo', () => {
     test('supports native x/y coordinate order and partial coordinate options', () => {
         const wrapper = createWrapper();
@@ -44,6 +49,20 @@ describe('scrollTo', () => {
         wrapper.vm.scrollTo({ left: 80 });
         expect(container.scrollLeft).toBe(80);
         expect(container.scrollTop).toBe(360);
+        wrapper.unmount();
+    });
+
+    test('ignores empty or conflicting target objects at runtime', () => {
+        const wrapper = createWrapper();
+        const container = wrapper.element;
+        container.scrollTop = 40;
+        container.scrollLeft = 20;
+
+        wrapper.vm.scrollTo({});
+        wrapper.vm.scrollTo({ top: 500, index: 1 });
+
+        expect(container.scrollTop).toBe(40);
+        expect(container.scrollLeft).toBe(20);
         wrapper.unmount();
     });
 
@@ -160,6 +179,58 @@ describe('scrollTo', () => {
 
         expect(container.scrollTop).toBe(0);
         expect(wrapper.find('tbody tr[data-row-key]').attributes('data-row-key')).toBe('10');
+        wrapper.unmount();
+    });
+
+    test('uses measured heights and sticky footer geometry for experimental boundaries and scrollbar metrics', () => {
+        const wrapper = createWrapper({
+            autoRowHeight: true,
+            footerData: [{ id: 'total', name: 'Total' }],
+            scrollbar: true,
+            scrollRowByRow: true,
+        });
+        Object.defineProperty(wrapper.find('.stk-footer').element, 'offsetHeight', { configurable: true, value: ROW_HEIGHT });
+        wrapper.vm.setAutoHeight(0, 40);
+        wrapper.vm.setAutoHeight(1, 50);
+        wrapper.vm.initVirtualScroll();
+
+        wrapper.vm.scrollTo({ position: 'bottom' });
+
+        const rowsHeight = 40 + 50 + (dataSource.length - 2) * ROW_HEIGHT;
+        const expectedScrollHeight = rowsHeight + ROW_HEIGHT * 2;
+        const expectedMaxScrollTop = expectedScrollHeight - 300;
+        const virtualScroll = getSetupState(wrapper, 'virtualScroll');
+        const scrollbar = getSetupState(wrapper, 'scrollbar');
+        expect(virtualScroll.scrollHeight).toBe(expectedScrollHeight);
+        expect(virtualScroll.maxScrollTop).toBe(expectedMaxScrollTop);
+        expect(virtualScroll.scrollTop).toBe(expectedMaxScrollTop);
+        expect(scrollbar.t).toBeCloseTo(300 - scrollbar.h, 0);
+        wrapper.unmount();
+    });
+
+    test('smooth experimental scrolling reaches the shared measured-height boundary', () => {
+        let frameTime = 0;
+        const requestAnimationFrameSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+            frameTime += 350;
+            callback(frameTime);
+            return frameTime;
+        });
+        const wrapper = createWrapper({
+            autoRowHeight: true,
+            footerData: [{ id: 'total', name: 'Total' }],
+            scrollbar: true,
+            scrollRowByRow: true,
+        });
+        wrapper.vm.setAutoHeight(0, 40);
+        wrapper.vm.setAutoHeight(1, 50);
+        wrapper.vm.initVirtualScroll();
+
+        wrapper.vm.scrollTo({ position: 'bottom', behavior: 'smooth' });
+
+        const rowsHeight = 40 + 50 + (dataSource.length - 2) * ROW_HEIGHT;
+        const expectedMaxScrollTop = rowsHeight + ROW_HEIGHT * 2 - 300;
+        expect(getSetupState(wrapper, 'virtualScroll').scrollTop).toBe(expectedMaxScrollTop);
+        requestAnimationFrameSpy.mockRestore();
         wrapper.unmount();
     });
 });

--- a/test/scrollTo.test.js
+++ b/test/scrollTo.test.js
@@ -1,0 +1,165 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { mount } from '@vue/test-utils';
+import { StkTable } from '@/StkTable';
+import { describe, expect, test, vi } from 'vitest';
+
+const ROW_HEIGHT = 28;
+const columns = [
+    { dataIndex: 'id', title: 'ID', width: 100 },
+    { dataIndex: 'name', title: 'Name', width: 160 },
+];
+const dataSource = Array.from({ length: 100 }, (_, id) => ({ id, name: `row-${id}` }));
+
+function createWrapper(extraProps = {}) {
+    const wrapper = mount(StkTable, {
+        props: {
+            rowKey: 'id',
+            columns,
+            dataSource,
+            virtual: true,
+            ...extraProps,
+        },
+    });
+    Object.defineProperty(wrapper.element, 'clientHeight', { configurable: true, value: 300 });
+    Object.defineProperty(wrapper.element, 'clientWidth', { configurable: true, value: 200 });
+    wrapper.vm.initVirtualScroll();
+    return wrapper;
+}
+
+describe('scrollTo', () => {
+    test('supports native x/y coordinate order and partial coordinate options', () => {
+        const wrapper = createWrapper();
+        const container = wrapper.element;
+
+        wrapper.vm.scrollTo(120, 240);
+        expect(container.scrollLeft).toBe(120);
+        expect(container.scrollTop).toBe(240);
+
+        wrapper.vm.scrollTo({ top: 360 });
+        expect(container.scrollLeft).toBe(120);
+        expect(container.scrollTop).toBe(360);
+
+        wrapper.vm.scrollTo({ left: 80 });
+        expect(container.scrollLeft).toBe(80);
+        expect(container.scrollTop).toBe(360);
+        wrapper.unmount();
+    });
+
+    test('forwards smooth behavior to native scrollTo', () => {
+        const wrapper = createWrapper();
+        const container = wrapper.element;
+        const nativeScrollTo = vi.fn(options => {
+            if (options.top !== undefined) container.scrollTop = options.top;
+            if (options.left !== undefined) container.scrollLeft = options.left;
+        });
+        Object.defineProperty(container, 'scrollTo', { configurable: true, value: nativeScrollTo });
+
+        wrapper.vm.scrollTo({ left: 30, top: 60, behavior: 'smooth' });
+        expect(nativeScrollTo).toHaveBeenCalledWith({ left: 30, top: 60, behavior: 'smooth' });
+        wrapper.unmount();
+    });
+
+    test('scrolls an index minimally by default and aligns it to top when debounce is false', () => {
+        const wrapper = createWrapper();
+        const container = wrapper.element;
+
+        container.scrollLeft = 25;
+        wrapper.vm.scrollTo({ index: 2 });
+        expect(container.scrollTop).toBe(0);
+        expect(container.scrollLeft).toBe(25);
+
+        wrapper.vm.scrollTo({ index: 20 });
+        expect(container.scrollTop).toBe(20 * ROW_HEIGHT + ROW_HEIGHT - (300 - ROW_HEIGHT));
+        expect(container.scrollLeft).toBe(0);
+
+        wrapper.vm.scrollTo({ index: 10, debounce: false });
+        expect(container.scrollTop).toBe(10 * ROW_HEIGHT);
+        expect(container.scrollLeft).toBe(0);
+        wrapper.unmount();
+    });
+
+    test('supports row keys and ignores missing rows', () => {
+        const wrapper = createWrapper();
+        const container = wrapper.element;
+
+        wrapper.vm.scrollTo({ key: 40, debounce: false });
+        expect(container.scrollTop).toBe(40 * ROW_HEIGHT);
+
+        wrapper.vm.scrollTo({ key: 'missing', debounce: false });
+        wrapper.vm.scrollTo({ index: -1, debounce: false });
+        wrapper.vm.scrollTo({ index: dataSource.length, debounce: false });
+        expect(container.scrollTop).toBe(40 * ROW_HEIGHT);
+
+        wrapper.vm.scrollTo({ key: 0, debounce: false });
+        expect(container.scrollTop).toBe(0);
+        wrapper.unmount();
+    });
+
+    test('resolves keys against the current display order', () => {
+        const wrapper = createWrapper({ dataSource: [...dataSource].reverse() });
+        const container = wrapper.element;
+
+        wrapper.vm.scrollTo({ key: 40, debounce: false });
+        expect(container.scrollTop).toBe(59 * ROW_HEIGHT);
+        wrapper.unmount();
+    });
+
+    test('supports top and bottom positions', () => {
+        const wrapper = createWrapper();
+        const container = wrapper.element;
+
+        container.scrollLeft = 90;
+        wrapper.vm.scrollTo({ position: 'bottom' });
+        expect(container.scrollTop).toBe(dataSource.length * ROW_HEIGHT - (300 - ROW_HEIGHT));
+        expect(container.scrollLeft).toBe(0);
+
+        wrapper.vm.scrollTo({ position: 'top' });
+        expect(container.scrollTop).toBe(0);
+        expect(container.scrollLeft).toBe(0);
+        wrapper.unmount();
+    });
+
+    test('uses measured auto row heights for index offsets', () => {
+        const wrapper = createWrapper({ autoRowHeight: true });
+        const container = wrapper.element;
+        wrapper.vm.setAutoHeight(0, 40);
+        wrapper.vm.setAutoHeight(1, 50);
+
+        wrapper.vm.scrollTo({ index: 2, debounce: false });
+        expect(container.scrollTop).toBe(90);
+        wrapper.unmount();
+    });
+
+    test('does not reserve header height in headless mode', () => {
+        const wrapper = createWrapper({ headless: true });
+        const container = wrapper.element;
+
+        wrapper.vm.scrollTo({ index: 20 });
+        expect(container.scrollTop).toBe(20 * ROW_HEIGHT + ROW_HEIGHT - 300);
+        wrapper.unmount();
+    });
+
+    test('keeps a target row clear of a sticky footer', () => {
+        const wrapper = createWrapper({ footerData: [{ id: 'total', name: 'Total' }] });
+        const container = wrapper.element;
+        Object.defineProperty(wrapper.find('.stk-footer').element, 'offsetHeight', { configurable: true, value: ROW_HEIGHT });
+
+        wrapper.vm.scrollTo({ index: 20 });
+        expect(container.scrollTop).toBe(20 * ROW_HEIGHT + ROW_HEIGHT - (300 - ROW_HEIGHT * 2));
+        wrapper.unmount();
+    });
+
+    test('updates simulated vertical scrolling mode', async () => {
+        const wrapper = createWrapper({ scrollbar: true, scrollRowByRow: true });
+        const container = wrapper.element;
+
+        wrapper.vm.scrollTo({ top: 10 * ROW_HEIGHT });
+        await wrapper.vm.$nextTick();
+
+        expect(container.scrollTop).toBe(0);
+        expect(wrapper.find('tbody tr[data-row-key]').attributes('data-row-key')).toBe('10');
+        wrapper.unmount();
+    });
+});

--- a/tsconfig.type-tests.json
+++ b/tsconfig.type-tests.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "allowJs": false,
+        "noEmit": true
+    },
+    "include": ["./src/vite-env.d.ts", "./type-tests/scrollTo.ts"],
+    "exclude": ["node_modules"]
+}

--- a/type-tests/scrollTo.ts
+++ b/type-tests/scrollTo.ts
@@ -1,0 +1,30 @@
+import type { CommonScrollToOptions, ScrollTo, ScrollToOptions } from '../src/StkTable';
+
+const commonOptions: CommonScrollToOptions = { behavior: 'smooth', debounce: false };
+
+const coordinates: ScrollToOptions = { left: 20 };
+const coordinatesWithTop: ScrollToOptions = { left: 20, top: 40, behavior: 'instant' };
+const indexTarget: ScrollToOptions = { index: 10, ...commonOptions };
+const keyTarget: ScrollToOptions = { key: 0, behavior: 'auto' };
+const positionTarget: ScrollToOptions = { position: 'bottom' };
+
+declare const scrollTo: ScrollTo;
+scrollTo(20, 40);
+scrollTo(coordinates);
+scrollTo(coordinatesWithTop);
+scrollTo(indexTarget);
+scrollTo(keyTarget);
+scrollTo(positionTarget);
+
+// @ts-expect-error a target is required
+const emptyTarget: ScrollToOptions = {};
+// @ts-expect-error coordinate and index targets are mutually exclusive
+const coordinateAndIndex: ScrollToOptions = { top: 500, index: 1 };
+// @ts-expect-error index and key targets are mutually exclusive
+const indexAndKey: ScrollToOptions = { index: 1, key: 'row-1' };
+// @ts-expect-error position cannot be combined with coordinates
+scrollTo({ position: 'top', left: 10 });
+
+void emptyTarget;
+void coordinateAndIndex;
+void indexAndKey;


### PR DESCRIPTION
## Summary

- align the exposed `scrollTo` API with Naive UI Virtual List and native `Element.scrollTo`
- support numeric x/y coordinates plus left/top, index, row key, and top/bottom option forms
- support `ScrollBehavior` and Naive UI-compatible debounce semantics for index/key scrolling
- export and document `ScrollTo`, `ScrollToOptions`, and `CommonScrollToOptions` from the package root
- make `ScrollToOptions` a mutually exclusive union that rejects empty and mixed targets
- use one measured-row-height and sticky-footer-aware vertical metrics model for targets, experimental clamping, wheel/end boundaries, and custom scrollbar geometry
- keep keyboard and area-selection scrolling on a private top/left helper so the public order change does not affect internal behavior
- update the OpenSpec contract, changelog, and Chinese/English/Japanese/Korean documentation

Reference: https://www.naiveui.com/zh-CN/os-theme/components/virtual-list

## Breaking change

The numeric overload now follows native x/y order: `scrollTo(left, top)`. Existing `scrollTo(top, left)` calls must swap their arguments or migrate to `scrollTo({ top, left })`.

## Review follow-up

Commit `6e4037c` addresses all three automated review findings:

- documents how to import and use all three public type exports
- rejects `{}`, `{ top, index }`, and other conflicting targets at compile time, with defensive runtime no-op handling
- prevents immediate and smooth experimental scrolling from being reclamped by the old fixed-height/footer-unaware maximum and keeps custom scrollbar metrics on the same model

## Validation

- 13 `scrollTo` runtime tests pass, including measured auto-row heights plus sticky footer in immediate and smooth experimental modes
- 46 targeted virtual-scroll tests pass across scrollTo, row reuse, virtual merge, and row merge suites
- `pnpm test:types` passes compile-time positive and negative public type cases
- TypeScript no-emit check passes
- production Vite build and declaration generation pass
- VitePress build passes for 252 documentation pages
- ESLint reports 0 errors (existing warnings remain)

The repository-wide default test command still has 23 unrelated existing failures confined to sorter tests without a DOM environment and one area-selection silent assertion; 109 tests pass and this update adds no new full-suite failure category.